### PR TITLE
Fix HDD error, mutex error and improve notifications

### DIFF
--- a/custom_components/hikvision_next/__init__.py
+++ b/custom_components/hikvision_next/__init__.py
@@ -7,7 +7,12 @@ import logging
 from httpx import TimeoutException
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
@@ -30,7 +35,12 @@ from .notifications import EventNotificationsView
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.CAMERA, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.CAMERA,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -62,7 +72,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinators[EVENTS_COORDINATOR] = EventsCoordinator(hass, isapi)
 
-    if isapi.device_info.support_holiday_mode or isapi.device_info.support_alarm_server:
+    if (
+        isapi.device_info.support_holiday_mode
+        or isapi.device_info.support_alarm_server
+    ):
         coordinators[SECONDARY_COORDINATOR] = SecondaryCoordinator(hass, isapi)
 
     hass.data[DOMAIN][entry.entry_id] = {
@@ -72,7 +85,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         **coordinators,
     }
 
-    if entry.data[DATA_SET_ALARM_SERVER] and isapi.device_info.support_alarm_server:
+    if (
+        entry.data[DATA_SET_ALARM_SERVER]
+        and isapi.device_info.support_alarm_server
+    ):
         await isapi.set_alarm_server(
             entry.data[DATA_ALARM_SERVER_HOST], ALARM_SERVER_PATH
         )
@@ -84,12 +100,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Only initialise view once if multiple instances of integration
     if get_first_instance_unique_id(hass) == entry.unique_id:
-        hass.http.register_view(EventNotificationsView)
+        hass.http.register_view(EventNotificationsView(hass))
 
     return True
 
 
-async def async_remove_config_entry_device(hass: HomeAssistant, config_entry, device_entry) -> bool:
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry, device_entry
+) -> bool:
     """Delete device if not entities"""
     if not device_entry.via_device_id:
         _LOGGER.error(

--- a/custom_components/hikvision_next/isapi.py
+++ b/custom_components/hikvision_next/isapi.py
@@ -637,7 +637,7 @@ class ISAPI:
                 POST, url, present="json", data=json.dumps(data)
             )
         except HTTPStatusError:
-            return True
+            return []
 
         response = json.loads(response)
 

--- a/custom_components/hikvision_next/isapi.py
+++ b/custom_components/hikvision_next/isapi.py
@@ -305,7 +305,7 @@ class ISAPI:
 
                     self.cameras.append(
                         IPCamera(
-                            id=camera_id,
+                            id=int(camera_id),
                             name=digital_camera.get("name"),
                             model=digital_camera.get(
                                 "sourceInputPortDescriptor", {}
@@ -314,9 +314,11 @@ class ISAPI:
                             firmware=digital_camera.get(
                                 "sourceInputPortDescriptor", {}
                             ).get("firmwareVersion"),
-                            input_port=digital_camera.get(
-                                "sourceInputPortDescriptor", {}
-                            ).get("srcInputPort"),
+                            input_port=int(
+                                digital_camera.get(
+                                    "sourceInputPortDescriptor", {}
+                                ).get("srcInputPort")
+                            ),
                             ip_addr=digital_camera.get(
                                 "sourceInputPortDescriptor", {}
                             ).get("ipAddress"),
@@ -361,7 +363,7 @@ class ISAPI:
                             name=analog_camera.get("name"),
                             model=analog_camera.get("resDesc"),
                             serial_no=device_serial_no,
-                            input_port=analog_camera.get("inputPort"),
+                            input_port=int(analog_camera.get("inputPort")),
                             streams=await self.get_camera_streams(camera_id),
                             supported_events=await self.get_camera_event_capabilities(
                                 supported_events,
@@ -679,7 +681,7 @@ class ISAPI:
             )
         else:
             raise HomeAssistantError(
-                f"You cannot enable {EVENTS[event.id]['label']} events.  Please disable {EVENTS[mutex_issues[0].event_id]['label']} on channels {mutex_issues[0].channels} first"
+                f"You cannot enable {EVENTS[event.id]['label']} events. Please disable {EVENTS[mutex_issues[0].event_id]['label']} on channels {mutex_issues[0].channels} first"
             )
 
     async def get_holiday_enabled_state(self, holiday_index=0) -> bool:
@@ -837,10 +839,6 @@ class ISAPI:
         channel_id = int(
             alert.get("channelID", alert.get("dynChannelID", "0"))
         )
-        if channel_id > 32:
-            # workaround for wrong channelId provided by NVR
-            # model: DS-7608NXI-I2/8P/S, Firmware: V4.61.067 or V4.62.200
-            channel_id = channel_id - 32
 
         event_id = alert.get("eventType")
         if not event_id or event_id == "duration":

--- a/custom_components/hikvision_next/notifications.py
+++ b/custom_components/hikvision_next/notifications.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from http import HTTPStatus
+from urllib.parse import urlparse
 
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
@@ -10,11 +12,15 @@ from homeassistant.const import CONTENT_TYPE_TEXT_PLAIN, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.util import slugify
-from http import HTTPStatus
 from requests_toolbelt.multipart import MultipartDecoder
 
-from .const import ALARM_SERVER_PATH, DOMAIN, HIKVISION_EVENT
-from .isapi import ISAPI, AlertInfo
+from .const import (
+    ALARM_SERVER_PATH,
+    DATA_ISAPI,
+    DOMAIN,
+    HIKVISION_EVENT,
+)
+from .isapi import ISAPI, AlertInfo, IPCamera
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,15 +37,20 @@ CONTENT_TYPE_IMAGE = "image/jpeg"
 class EventNotificationsView(HomeAssistantView):
     """Event notifications listener."""
 
-    requires_auth = False
-    url = ALARM_SERVER_PATH
-    name = DOMAIN
+    def __init__(self, hass: HomeAssistant):
+        self.requires_auth = False
+        self.url = ALARM_SERVER_PATH
+        self.name = DOMAIN
+        self.isapi: ISAPI
+        self.hass = hass
 
     async def post(self, request: web.Request):
         """Accept the POST request from NVR or IP Camera"""
 
         try:
             _LOGGER.debug("--- Incoming event notification ---")
+            _LOGGER.debug("Source: %s", request.remote)
+            self.isapi = self.get_isapi_instance(request.remote)
             xml = await self.parse_event_request(request)
             _LOGGER.debug("alert info: %s", xml)
             self.trigger_sensor(request.app["hass"], xml)
@@ -50,6 +61,24 @@ class EventNotificationsView(HomeAssistantView):
             status=HTTPStatus.OK, content_type=CONTENT_TYPE_TEXT_PLAIN
         )
         return response
+
+    def get_isapi_instance(self, device_ip) -> ISAPI:
+        """Get isapi instance for device sending alert"""
+        # Get list of instances
+        try:
+            entry = [
+                entry
+                for entry in self.hass.config_entries.async_entries(DOMAIN)
+                if not entry.disabled_by
+                and urlparse(entry.data.get("host")).hostname == device_ip
+            ][0]
+
+            config = self.hass.data[DOMAIN][entry.entry_id]
+
+            return config.get(DATA_ISAPI)
+
+        except IndexError:
+            return None
 
     async def parse_event_request(self, request: web.Request) -> str:
         """Extract XML content from multipart request or from simple request"""
@@ -77,60 +106,56 @@ class EventNotificationsView(HomeAssistantView):
                     _LOGGER.debug("image found")
 
         if not xml:
-            raise ValueError(f"Unexpected event Content-Type {content_type_header}")
+            raise ValueError(
+                f"Unexpected event Content-Type {content_type_header}"
+            )
         return xml
+
+    def get_alert_info(self, xml: str) -> AlertInfo:
+        """Parse incoming EventNotificationAlert XML message."""
+
+        alert = ISAPI.parse_event_notification(xml)
+
+        if alert.channel_id > 32:
+            # channel id above 32 is an IP camera
+            # On DVRs that support analog cameras 33 may not be
+            # camera 1 but camera 5 for example
+            try:
+                alert.channel_id = [
+                    camera.id
+                    for camera in self.isapi.cameras
+                    if isinstance(camera, IPCamera)
+                    and camera.input_port == alert.channel_id - 32
+                ][0]
+            except IndexError:
+                alert.channel_id = alert.channel_id - 32
+
+        return alert
 
     def trigger_sensor(self, hass: HomeAssistant, xml: str) -> None:
         """Determine entity and set binary sensor state"""
 
-        alert = ISAPI.parse_event_notification(xml)
-        _LOGGER.debug(alert)
-        device_serial = alert.device_serial_no
+        alert = self.get_alert_info(xml)
+        _LOGGER.debug("Alert: %s", alert)
 
-        if not device_serial and alert.mac:
-            # get device_serial by mac
-            device_registry = dr.async_get(hass)
-            hass_device = device_registry.async_get_device(
-                set(),
-                connections={(dr.CONNECTION_NETWORK_MAC, alert.mac)},
-            )
-            if hass_device:
-                device_serial = list(hass_device.identifiers)[0][1]
-
-        if not device_serial or alert.channel_id == 0:
-            raise ValueError("Cannot determine entity")
-
-        entity_id = f"binary_sensor.{slugify(device_serial.lower())}_{alert.channel_id}_{alert.event_id}"
+        serial_no = self.isapi.device_info.serial_no.lower()
+        entity_id = (
+            f"binary_sensor.{slugify(serial_no)}_{alert.channel_id}"
+            f"_{alert.event_id}"
+        )
         entity = hass.states.get(entity_id)
         if entity:
             hass.states.async_set(entity_id, STATE_ON, entity.attributes)
-            self.fire_hass_event(hass, device_serial, alert)
+            self.fire_hass_event(hass, alert)
         else:
             raise ValueError(f"Entity not found {entity_id}")
 
-    def fire_hass_event(
-        self, hass: HomeAssistant, device_serial: str, alert: AlertInfo
-    ):
-        """ Fire HASS event"""
-        device_registry = dr.async_get(hass)
-        if not alert.mac:
-            # Must be analog camera
-            device_serial = f"{device_serial}-VI{alert.channel_id}"
-
-        device_serial = f"{device_serial}-VI{alert.channel_id}"
-        hass_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_serial)},
-            connections=None,
-        )
-
-        if hass_device:
-            device_name = hass_device.name
-        else:
-            device_name = "Unknown"
-
+    def fire_hass_event(self, hass: HomeAssistant, alert: AlertInfo):
+        """Fire HASS event"""
+        camera = self.isapi.get_camera_by_id(alert.channel_id)
         message = {
             "channel_id": alert.channel_id,
-            "camera_name": device_name,
+            "camera_name": camera.name,
             "event_id": alert.event_id,
         }
 

--- a/custom_components/hikvision_next/sensor.py
+++ b/custom_components/hikvision_next/sensor.py
@@ -27,7 +27,9 @@ ALARM_SERVER_SETTINGS = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add diagnostic sensors for hikvision alarm server settings."""
 
@@ -83,7 +85,9 @@ class HDDSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator, hdd: HDDInfo) -> None:
         super().__init__(coordinator)
         isapi = coordinator.isapi
-        self._attr_unique_id = f"{isapi.device_info.serial_no}_{hdd.id}_{hdd.name}"
+        self._attr_unique_id = (
+            f"{isapi.device_info.serial_no}_{hdd.id}_{hdd.name}"
+        )
         self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
         self._attr_device_info = isapi.get_device_info()
         self._attr_name = f"HDD {hdd.id}"
@@ -91,7 +95,7 @@ class HDDSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        hdd = self.coordinator.isapi.device_info.storage[self.hdd.id - 1]
+        hdd = self.coordinator.isapi.get_storage_device_by_id(self.hdd.id)
         return str(hdd.status).upper() if hdd else None
 
     @property


### PR DESCRIPTION
- Fixes issue #58 - HDD error if HDD id does nto start at 1
- Fixes issue whereby enabling events switch can cause error due to no mutex function on IP camera
- Improves notifications whereby wrong entity can be chosen and now supports multiple instances
- Improves fire event function to now include camera name correctly