### PR TITLE
Valide "hdd" element is in storage_info list

### DIFF
--- a/custom_components/hikvision_next/isapi.py
+++ b/custom_components/hikvision_next/isapi.py
@@ -481,8 +481,9 @@ class ISAPI:
             storage_info = [storage_info]
 
         _LOGGER.debug("%s/ISAPI/ContentMgmt/Storage %s", self.isapi.host, storage_info)
-
-        for storage in storage_info:
+        if "hdd" not in storage_info: return storage_list
+                
+        for storage in storage_info:               
             storage = storage.get("hdd")
             if not isinstance(storage, list):
                 storage = [storage]

--- a/custom_components/hikvision_next/isapi.py
+++ b/custom_components/hikvision_next/isapi.py
@@ -518,8 +518,8 @@ class ISAPI:
         _LOGGER.debug("%s/ISAPI/ContentMgmt/Storage %s", self.isapi.host, storage_info)
 
         if "hdd" not in storage_info: return storage_list
-                
-        for storage in storage_info:               
+
+        for storage in storage_info:
             storage = storage.get("hdd")
             if not isinstance(storage, list):
                 storage = [storage]
@@ -535,6 +535,7 @@ class ISAPI:
                             freespace=int(hdd.get("freeSpace")),
                             property=hdd.get("property"),
                         )
+                    )
 
         return storage_list
 


### PR DESCRIPTION
Adressing issue #85 

storage_info does not contain any "hdd" element if the camera has no storage.

> 2023-07-05 19:41:41.925 DEBUG (MainThread) [custom_components.hikvision_next.isapi] http://hof.mine.de/ISAPI/ContentMgmt/Storage [{'@version': '1.0', '@xmlns': 'http://www.hikvision.com/ver10/XMLSchema', '@size': '8'}]

Added a check to prevent the for loop executing, preventing calling _storage.get("hdd")_ which is going to cause an exception. Instead directly return an empty hdd list.
