### PR TITLE
NVR IO Port Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The Home Assistant integration for Hikvision NVRs and IP cameras. Receives and s
 - Camera entities for main and sub streams
 - Real-time Acusense events notifications through binary sensors and HA events (hikvision_next_event)
 - Switches for Acusense events detection
+- Switches for NVR Outputs
 - Holiday mode switch (allows to switch continuous recording with appropriate NVR setup)
 - Tracking Alarm Server settings for diagnostic purposes
 - Basic and digest authentication support
@@ -23,6 +24,7 @@ The Home Assistant integration for Hikvision NVRs and IP cameras. Receives and s
 - Line Crossing
 - Region Entrance
 - Region Exiting
+- NVR Input Triggers
 
 **NOTE**
 Events must be set to alert the surveillance center in Linkage Action for HA to be notified.  An attribute on the event switch shows if this is set.

--- a/custom_components/hikvision_next/binary_sensor.py
+++ b/custom_components/hikvision_next/binary_sensor.py
@@ -25,8 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             entities.append(CameraEventBinarySensor(isapi, camera, event))
 
     # NVR Events
-    for io_event in isapi.device_info.supported_events:
-        entities.append(NVREventBinarySensor(isapi, io_event))
+    if isapi.device_info.is_nvr:
+        for io_event in isapi.device_info.supported_events:
+            entities.append(NVREventBinarySensor(isapi, io_event))
 
     async_add_entities(entities)
 

--- a/custom_components/hikvision_next/binary_sensor.py
+++ b/custom_components/hikvision_next/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DATA_ISAPI, DOMAIN, EVENTS
-from .isapi import AnalogCamera, EventInfo, IPCamera
+from .isapi import ISAPI, AnalogCamera, EventInfo, IPCamera
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -18,14 +18,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     isapi = config[DATA_ISAPI]
 
     entities = []
+
+    # Camera Events
     for camera in isapi.cameras:
         for event in camera.supported_events:
-            entities.append(EventBinarySensor(isapi, camera, event))
+            entities.append(CameraEventBinarySensor(isapi, camera, event))
+
+    # NVR Events
+    for io_event in isapi.device_info.supported_events:
+        entities.append(NVREventBinarySensor(isapi, io_event))
 
     async_add_entities(entities)
 
 
-class EventBinarySensor(BinarySensorEntity):
+class CameraEventBinarySensor(BinarySensorEntity):
     """Event detection sensor."""
 
     _attr_has_entity_name = True
@@ -37,3 +43,17 @@ class EventBinarySensor(BinarySensorEntity):
         self._attr_name = EVENTS[event.id]["label"]
         self._attr_device_class = EVENTS[event.id]["device_class"]
         self._attr_device_info = isapi.get_device_info(camera.id)
+
+
+class NVREventBinarySensor(BinarySensorEntity):
+    """IO Event detection sensor."""
+
+    _attr_has_entity_name = True
+    _attr_is_on = False
+
+    def __init__(self, isapi: ISAPI, event: EventInfo) -> None:
+        self.entity_id = ENTITY_ID_FORMAT.format(event.unique_id)
+        self._attr_unique_id = self.entity_id
+        self._attr_name = f"{EVENTS[event.id]['label']} {event.channel_id}"
+        self._attr_device_class = EVENTS[event.id]["device_class"]
+        self._attr_device_info = isapi.get_device_info(0)

--- a/custom_components/hikvision_next/const.py
+++ b/custom_components/hikvision_next/const.py
@@ -21,9 +21,11 @@ ALARM_SERVER_SENSOR_LABEL_FORMAT = "Alarm Server {}"
 
 DEVICE_TYPE_IP_CAMERA = "IPCamera"
 DEVICE_TYPE_ANALOG_CAMERA = "AnalogCamera"
+DEVICE_TYPE_NVR = "NVR"
 
 HIKVISION_EVENT = f"{DOMAIN}_event"
 EVENT_BASIC: Final = "basic"
+EVENT_NVR_BASIC: Final = "nvr_basic"
 EVENT_SMART: Final = "smart"
 EVENTS = {
     "motiondetection": {
@@ -78,6 +80,14 @@ EVENTS = {
         "slug": "regionExiting",
         "device_class": BinarySensorDeviceClass.MOTION,
     },
+    "io": {
+        "type": EVENT_NVR_BASIC,
+        "label": "Alarm Input",
+        "channel_attr": "inputIOPortID",
+        "url_path": "IO/inputs",
+        "slug": "IOInputPort",
+        "device_class": BinarySensorDeviceClass.MOTION
+    }
 }
 
 EVENTS_ALTERNATE_ID = {

--- a/custom_components/hikvision_next/coordinator.py
+++ b/custom_components/hikvision_next/coordinator.py
@@ -10,6 +10,7 @@ import async_timeout
 from homeassistant.components.switch import ENTITY_ID_FORMAT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import slugify
 
 from .const import DATA_ALARM_SERVER_HOST, DOMAIN, HOLIDAY_MODE
 from .isapi import ISAPI
@@ -55,6 +56,17 @@ class EventsCoordinator(DataUpdateCoordinator):
                     data[entity_id] = await self.isapi.get_event_enabled_state(event)
                 except Exception as ex:  # pylint: disable=broad-except
                     self.isapi.handle_exception(ex, f"Cannot fetch state for {event.id}")
+
+            # Get NVR outputs status
+            if self.isapi.device_info.is_nvr:
+                for i in range(1, self.isapi.device_info.output_ports + 1):
+                    try:
+                        entity_id = ENTITY_ID_FORMAT.format(
+                            f"{slugify(self.isapi.device_info.serial_no.lower())}_{i}_alarm_output"
+                        )
+                        data[entity_id] = await self.isapi.get_port_status("output", i)
+                    except Exception as ex:  # pylint: disable=broad-except
+                        self.isapi.handle_exception(ex, f"Cannot fetch state for {event.id}")
 
             # Refresh HDD data
             try:

--- a/custom_components/hikvision_next/coordinator.py
+++ b/custom_components/hikvision_next/coordinator.py
@@ -38,6 +38,8 @@ class EventsCoordinator(DataUpdateCoordinator):
         """Update data via ISAPI"""
         async with async_timeout.timeout(30):
             data = {}
+
+            # Get camera event status
             for camera in self.isapi.cameras:
                 for event in camera.supported_events:
                     try:
@@ -45,6 +47,14 @@ class EventsCoordinator(DataUpdateCoordinator):
                         data[entity_id] = await self.isapi.get_event_enabled_state(event)
                     except Exception as ex:  # pylint: disable=broad-except
                         self.isapi.handle_exception(ex, f"Cannot fetch state for {event.id}")
+
+            # Get NVR event status
+            for event in self.isapi.device_info.supported_events:
+                try:
+                    entity_id = ENTITY_ID_FORMAT.format(event.unique_id)
+                    data[entity_id] = await self.isapi.get_event_enabled_state(event)
+                except Exception as ex:  # pylint: disable=broad-except
+                    self.isapi.handle_exception(ex, f"Cannot fetch state for {event.id}")
 
             # Refresh HDD data
             try:

--- a/custom_components/hikvision_next/diagnostics.py
+++ b/custom_components/hikvision_next/diagnostics.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import DATA_ISAPI, DOMAIN
+from .const import DATA_ISAPI, DOMAIN, EVENTS_COORDINATOR
 
 GET = "get"
 
@@ -35,6 +35,7 @@ async def _async_get_diagnostics(
     device: DeviceEntry | None = None,
 ) -> dict[str, Any]:
     isapi = hass.data[DOMAIN][entry.entry_id][DATA_ISAPI]
+    coordinator = hass.data[DOMAIN][entry.entry_id][EVENTS_COORDINATOR]
 
     # Get info set
     info = {}
@@ -57,6 +58,9 @@ async def _async_get_diagnostics(
                 }
             )
     info.update({"Event States": event_states})
+
+    # Event coordinator data
+    info.update({"Entity Data": to_json(coordinator.data)})
 
     # Add raw device info
     info.update(await get_isapi_data("RAW Device Info", isapi.isapi.System.deviceInfo, "DeviceInfo"))

--- a/custom_components/hikvision_next/isapi.py
+++ b/custom_components/hikvision_next/isapi.py
@@ -24,8 +24,10 @@ from homeassistant.util import slugify
 from .const import (
     DEVICE_TYPE_ANALOG_CAMERA,
     DEVICE_TYPE_IP_CAMERA,
+    DEVICE_TYPE_NVR,
     DOMAIN,
     EVENT_BASIC,
+    EVENT_NVR_BASIC,
     EVENTS,
     EVENTS_ALTERNATE_ID,
     MUTEX_ALTERNATE_IDS,
@@ -75,6 +77,7 @@ class EventInfo:
     """Holds event info of particular device"""
 
     id: str
+    channel_id: int
     unique_id: str
     url: str
     notifiers: list[str] = field(default_factory=list)
@@ -140,6 +143,7 @@ class HikDeviceInfo:
     output_ports: int = 0
     rtsp_port: int = 554
     storage: list[HDDInfo] = field(default_factory=list)
+    supported_events: list[EventInfo] = field(default_factory=list)
 
 
 @dataclass
@@ -172,6 +176,7 @@ class ISAPI:
         self.host = host
         self.device_info = HikDeviceInfo()
         self.cameras: list[IPCamera | AnalogCamera] = []
+        self.supported_events: list[SupportedEventsInfo] = []
 
     async def get_hardware_info(self):
         """Get base device data."""
@@ -182,6 +187,9 @@ class ISAPI:
         # Get device capabilities
         capabilities = (await self.isapi.System.capabilities(method=GET)).get("DeviceCap", {})
         _LOGGER.debug("%s/ISAPI/System/capabilities %s", self.isapi.host, capabilities)
+
+        # Get all supported events to reduce isapi queries
+        self.supported_events = await self.get_supported_events_info()
 
         # Set DeviceInfo
         self.device_info = HikDeviceInfo(
@@ -202,6 +210,7 @@ class ISAPI:
             input_ports=int(deep_get(capabilities, "SysCap.IOCap.IOInputPortNums", 0)),
             output_ports=int(deep_get(capabilities, "SysCap.IOCap.IOOutputPortNums", 0)),
             storage=await self.get_storage_devices(),
+            supported_events=await self.get_nvr_event_capabilities(hw_info.get("serialNumber"), self.supported_events)
         )
 
         await self.get_protocols()
@@ -213,9 +222,6 @@ class ISAPI:
 
     async def get_cameras(self):
         """Get camera objects for all connected cameras."""
-
-        # Get all supported events to reduce isapi queries
-        supported_events = await self.get_supported_events_info()
 
         if not self.device_info.is_nvr:
             # Get single IP camera
@@ -230,7 +236,7 @@ class ISAPI:
                     ip_addr=self.device_info.ip_address,
                     streams=await self.get_camera_streams(1),
                     supported_events=await self.get_camera_event_capabilities(
-                        supported_events, 1, DEVICE_TYPE_IP_CAMERA
+                        self.supported_events, 1, DEVICE_TYPE_IP_CAMERA
                     ),
                 )
             )
@@ -277,7 +283,7 @@ class ISAPI:
                             ip_port=source.get("managePortNo"),
                             streams=await self.get_camera_streams(camera_id),
                             supported_events=await self.get_camera_event_capabilities(
-                                supported_events,
+                                self.supported_events,
                                 camera_id,
                                 DEVICE_TYPE_IP_CAMERA,
                             ),
@@ -314,7 +320,7 @@ class ISAPI:
                             input_port=int(analog_camera.get("inputPort")),
                             streams=await self.get_camera_streams(camera_id),
                             supported_events=await self.get_camera_event_capabilities(
-                                supported_events,
+                                self.supported_events,
                                 camera_id,
                                 DEVICE_TYPE_ANALOG_CAMERA,
                             ),
@@ -354,12 +360,17 @@ class ISAPI:
         """Get events support by camera device and integration"""
         events = []
 
-        camera_supported_events = [s for s in supported_events if s.channel_id == int(channel_id)]
+        camera_supported_events = [s for s in supported_events if (
+            s.channel_id == int(channel_id)
+            and s.event_id in EVENTS
+            and EVENTS[s.event_id].get("type") != EVENT_NVR_BASIC
+        )]
 
         for event in camera_supported_events:
             if EVENTS.get(event.event_id):
                 event_info = EventInfo(
                     id=event.event_id,
+                    channel_id=event.channel_id,
                     unique_id=f"{slugify(self.device_info.serial_no.lower())}_{channel_id}_{event.event_id}",
                     url=self.get_event_url(
                         event.event_id,
@@ -370,6 +381,34 @@ class ISAPI:
                     notifiers=event.notifications,
                 )
                 events.append(event_info)
+        return events
+    
+    async def get_nvr_event_capabilities(
+        self, serial_no: str, supported_events: list[SupportedEventsInfo]
+    ) -> list[EventInfo]:
+        """Get events supported by the NVR"""
+        events = []
+
+        nvr_supported_events = [s for s in supported_events if (
+            s.event_id in EVENTS and EVENTS[s.event_id].get("type") == EVENT_NVR_BASIC
+        )]
+
+        _LOGGER.debug("NVR SUPPORTED EVENTS: %s", nvr_supported_events)
+
+        for event in nvr_supported_events:
+            event_info = EventInfo(
+                id=event.event_id,
+                channel_id=event.channel_id,
+                unique_id=f"{slugify(serial_no)}_{event.channel_id}_{event.event_id}",
+                url=self.get_event_url(
+                    event.event_id,
+                    event.channel_id,
+                    True,
+                    DEVICE_TYPE_NVR,
+                ),
+                notifiers=event.notifications,
+            )
+            events.append(event_info)
         return events
 
     async def get_supported_events_info(self):
@@ -387,7 +426,7 @@ class ISAPI:
             event_type = support_event.get("eventType")
             channel = support_event.get(
                 "videoInputChannelID",
-                support_event.get("dynVideoInputChannelID", 0),
+                support_event.get("dynVideoInputChannelID", support_event.get("inputIOPortID", 0)),
             )
             notifications = support_event.get("EventTriggerNotificationList", {})
 
@@ -416,18 +455,22 @@ class ISAPI:
 
         return events
 
-    def get_event_url(self, event_id: str, channel_id: int, is_nvr: bool, camera_type: str) -> str:
+    def get_event_url(self, event_id: str, channel_id: int, is_nvr: bool, device_type: str) -> str:
         """Get event ISAPI URL."""
 
         event_type = EVENTS[event_id]["type"]
-        slug = EVENTS[event_id]["slug"]
+        url_path = EVENTS[event_id].get("url_path")
+        slug = EVENTS[event_id]["slug"] if not url_path else url_path
 
-        if is_nvr and camera_type == DEVICE_TYPE_IP_CAMERA and event_type == EVENT_BASIC:
+        if is_nvr and device_type == DEVICE_TYPE_IP_CAMERA and event_type == EVENT_BASIC:
             # ISAPI/ContentMgmt/InputProxy/channels/{channel_id}/video/{event}
             url = f"ContentMgmt/InputProxy/channels/{channel_id}/video/{slug}"
-        elif (is_nvr and camera_type == DEVICE_TYPE_ANALOG_CAMERA or not is_nvr) and event_type == EVENT_BASIC:
+        elif (is_nvr and device_type == DEVICE_TYPE_ANALOG_CAMERA or not is_nvr) and event_type == EVENT_BASIC:
             # ISAPI/System/Video/inputs/channels/{channel_id}/{event}
             url = f"System/Video/inputs/channels/{channel_id}/{slug}"
+        elif is_nvr and device_type == DEVICE_TYPE_NVR and event_type == EVENT_NVR_BASIC:
+            # ISAPI/System/{event}/inputs/{channel_id}
+            url = f"System/{slug}/{channel_id}"
         else:
             # ISAPI/Smart/{event}/{channel_id}
             url = f"Smart/{slug}/{channel_id}"
@@ -738,8 +781,6 @@ class ISAPI:
 
         alert = data["EventNotificationAlert"]
 
-        channel_id = int(alert.get("channelID", alert.get("dynChannelID", "0")))
-
         event_id = alert.get("eventType")
         if not event_id or event_id == "duration":
             # <EventNotificationAlert version="2.0"
@@ -748,6 +789,11 @@ class ISAPI:
         # handle alternate event type
         if EVENTS_ALTERNATE_ID.get(event_id):
             event_id = EVENTS_ALTERNATE_ID[event_id]
+
+        if EVENTS.get(event_id) and EVENTS[event_id].get("channel_attr"):
+            channel_id = int(alert.get(EVENTS[event_id].get("channel_attr")))
+        else:
+            channel_id = int(alert.get("channelID", alert.get("dynChannelID", 0)))
 
         device_serial = None
         if alert.get("Extensions"):

--- a/custom_components/hikvision_next/isapi.py
+++ b/custom_components/hikvision_next/isapi.py
@@ -382,7 +382,7 @@ class ISAPI:
                 )
                 events.append(event_info)
         return events
-    
+
     async def get_nvr_event_capabilities(
         self, serial_no: str, supported_events: list[SupportedEventsInfo]
     ) -> list[EventInfo]:
@@ -393,13 +393,11 @@ class ISAPI:
             s.event_id in EVENTS and EVENTS[s.event_id].get("type") == EVENT_NVR_BASIC
         )]
 
-        _LOGGER.debug("NVR SUPPORTED EVENTS: %s", nvr_supported_events)
-
         for event in nvr_supported_events:
             event_info = EventInfo(
                 id=event.event_id,
                 channel_id=event.channel_id,
-                unique_id=f"{slugify(serial_no)}_{event.channel_id}_{event.event_id}",
+                unique_id=f"{slugify(serial_no.lower())}_{event.channel_id}_{event.event_id}",
                 url=self.get_event_url(
                     event.event_id,
                     event.channel_id,
@@ -552,7 +550,7 @@ class ISAPI:
         except IndexError:
             # Storage id does not exist
             return None
-        
+
     async def get_port_status(self, port_type: str, port_no: int) -> str:
         """Get status of physical ports"""
         if port_type == "input":
@@ -573,7 +571,6 @@ class ISAPI:
         else:
             data["IOPortData"] = {"outputState": "low"}
 
-        _LOGGER.debug("STATUS: %s", data)
         xml = xmltodict.unparse(data)
         response = await self.isapi.System.IO.outputs[port_no].trigger(method=PUT, data=xml)
         _LOGGER.debug("[PUT] %s/ISAPI/System/IO/outputs/%s/trigger %s", self.isapi.host, port_no, response)

--- a/custom_components/hikvision_next/switch.py
+++ b/custom_components/hikvision_next/switch.py
@@ -33,7 +33,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     entities = []
     for camera in events_coordinator.isapi.cameras:
         for event in camera.supported_events:
-            entities.append(EventSwitch(camera, event, events_coordinator))
+            entities.append(CameraEventSwitch(camera, event, events_coordinator))
+
+    for event in events_coordinator.isapi.device_info.supported_events:
+        entities.append(NVREventSwitch(event, events_coordinator))
 
     if secondary_coordinator.isapi.device_info.support_holiday_mode:
         entities.append(HolidaySwitch(secondary_coordinator))
@@ -41,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities(entities)
 
 
-class EventSwitch(CoordinatorEntity, SwitchEntity):
+class CameraEventSwitch(CoordinatorEntity, SwitchEntity):
     """Detection events switch."""
 
     _attr_has_entity_name = True
@@ -71,6 +74,47 @@ class EventSwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         try:
             await self.coordinator.isapi.set_event_enabled_state(self.camera.id, self.event, False)
+        except Exception as ex:
+            raise ex
+        finally:
+            await self.coordinator.async_request_refresh()
+
+    @property
+    def extra_state_attributes(self):
+        attrs = {}
+        attrs["notify_HA"] = True if "center" in self.event.notifiers else False
+        return attrs
+
+
+class NVREventSwitch(CoordinatorEntity, SwitchEntity):
+    """Detection events switch."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:eye-outline"
+
+    def __init__(self, event: EventInfo, coordinator) -> None:
+        super().__init__(coordinator)
+        self.entity_id = ENTITY_ID_FORMAT.format(event.unique_id)
+        self._attr_unique_id = self.entity_id
+        self._attr_device_info = coordinator.isapi.get_device_info(0)
+        self._attr_name = f"{EVENT_SWITCH_LABEL_FORMAT.format(EVENTS[event.id]['label'])} {event.channel_id}"
+        self.event = event
+
+    @property
+    def is_on(self) -> bool | None:
+        return self.coordinator.data.get(self.entity_id)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        try:
+            await self.coordinator.isapi.set_event_enabled_state(self.event.channel_id, self.event, True)
+        except Exception as ex:
+            raise ex
+        finally:
+            await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        try:
+            await self.coordinator.isapi.set_event_enabled_state(self.event.channel_id, self.event, False)
         except Exception as ex:
             raise ex
         finally:


### PR DESCRIPTION
@maciej-or this PR adds new functionality to support the IO ports on an NVR.  I have tested with both my NVR and a single IP camera (with no IO support).  I have not been able to test on a single IP camera with IO support.

I have limited the output port switch to only show if an NVR for now as not sure if urls/xml same on a camera.

Adds switches to enable or disable IO events by port on NVR
Adds switch to turn on/off output ports of NVR
Adds sensors to show input port event