### PR TITLE
IO events v2

### DIFF
--- a/custom_components/hikvision_next/binary_sensor.py
+++ b/custom_components/hikvision_next/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DATA_ISAPI, DOMAIN, EVENTS
-from .isapi import ISAPI, AnalogCamera, EventInfo, IPCamera
+from .isapi import EventInfo
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -22,39 +22,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     # Camera Events
     for camera in isapi.cameras:
         for event in camera.supported_events:
-            entities.append(CameraEventBinarySensor(isapi, camera, event))
+            entities.append(EventBinarySensor(isapi, camera.id, event))
 
     # NVR Events
     if isapi.device_info.is_nvr:
-        for io_event in isapi.device_info.supported_events:
-            entities.append(NVREventBinarySensor(isapi, io_event))
+        for event in isapi.device_info.supported_events:
+            entities.append(EventBinarySensor(isapi, 0, event))
 
     async_add_entities(entities)
 
 
-class CameraEventBinarySensor(BinarySensorEntity):
+class EventBinarySensor(BinarySensorEntity):
     """Event detection sensor."""
 
     _attr_has_entity_name = True
     _attr_is_on = False
 
-    def __init__(self, isapi, camera: AnalogCamera | IPCamera, event: EventInfo) -> None:
+    def __init__(self, isapi, device_id: int, event: EventInfo) -> None:
         self.entity_id = ENTITY_ID_FORMAT.format(event.unique_id)
         self._attr_unique_id = self.entity_id
-        self._attr_name = EVENTS[event.id]["label"]
+        self._attr_name = f"{EVENTS[event.id]['label']}{' ' + str(event.io_port_id) if event.io_port_id != 0 else ''}"
         self._attr_device_class = EVENTS[event.id]["device_class"]
-        self._attr_device_info = isapi.get_device_info(camera.id)
-
-
-class NVREventBinarySensor(BinarySensorEntity):
-    """IO Event detection sensor."""
-
-    _attr_has_entity_name = True
-    _attr_is_on = False
-
-    def __init__(self, isapi: ISAPI, event: EventInfo) -> None:
-        self.entity_id = ENTITY_ID_FORMAT.format(event.unique_id)
-        self._attr_unique_id = self.entity_id
-        self._attr_name = f"{EVENTS[event.id]['label']} {event.channel_id}"
-        self._attr_device_class = EVENTS[event.id]["device_class"]
-        self._attr_device_info = isapi.get_device_info(0)
+        self._attr_device_info = isapi.get_device_info(device_id)

--- a/custom_components/hikvision_next/const.py
+++ b/custom_components/hikvision_next/const.py
@@ -19,13 +19,12 @@ EVENT_SWITCH_LABEL_FORMAT = "{} Detection"
 HOLIDAY_MODE_SWITCH_LABEL = "Holiday mode"
 ALARM_SERVER_SENSOR_LABEL_FORMAT = "Alarm Server {}"
 
-DEVICE_TYPE_IP_CAMERA = "IPCamera"
-DEVICE_TYPE_ANALOG_CAMERA = "AnalogCamera"
-DEVICE_TYPE_NVR = "NVR"
+CONNECTION_TYPE_DIRECT = "Direct"
+CONNECTION_TYPE_PROXIED = "Proxied"
 
 HIKVISION_EVENT = f"{DOMAIN}_event"
 EVENT_BASIC: Final = "basic"
-EVENT_NVR_BASIC: Final = "nvr_basic"
+EVENT_IO: Final = "io"
 EVENT_SMART: Final = "smart"
 EVENTS = {
     "motiondetection": {
@@ -81,11 +80,11 @@ EVENTS = {
         "device_class": BinarySensorDeviceClass.MOTION,
     },
     "io": {
-        "type": EVENT_NVR_BASIC,
+        "type": EVENT_IO,
         "label": "Alarm Input",
-        "channel_attr": "inputIOPortID",
-        "url_path": "IO/inputs",
-        "slug": "IOInputPort",
+        "slug": "inputs",
+        "direct_node": "IOInputPort",
+        "proxied_node": "IOProxyInputPort",
         "device_class": BinarySensorDeviceClass.MOTION
     }
 }

--- a/custom_components/hikvision_next/coordinator.py
+++ b/custom_components/hikvision_next/coordinator.py
@@ -57,16 +57,15 @@ class EventsCoordinator(DataUpdateCoordinator):
                 except Exception as ex:  # pylint: disable=broad-except
                     self.isapi.handle_exception(ex, f"Cannot fetch state for {event.id}")
 
-            # Get NVR outputs status
-            if self.isapi.device_info.is_nvr:
-                for i in range(1, self.isapi.device_info.output_ports + 1):
-                    try:
-                        entity_id = ENTITY_ID_FORMAT.format(
-                            f"{slugify(self.isapi.device_info.serial_no.lower())}_{i}_alarm_output"
-                        )
-                        data[entity_id] = await self.isapi.get_port_status("output", i)
-                    except Exception as ex:  # pylint: disable=broad-except
-                        self.isapi.handle_exception(ex, f"Cannot fetch state for {event.id}")
+            # Get output port(s) status
+            for i in range(1, self.isapi.device_info.output_ports + 1):
+                try:
+                    entity_id = ENTITY_ID_FORMAT.format(
+                        f"{slugify(self.isapi.device_info.serial_no.lower())}_{i}_alarm_output"
+                    )
+                    data[entity_id] = await self.isapi.get_port_status("output", i)
+                except Exception as ex:  # pylint: disable=broad-except
+                    self.isapi.handle_exception(ex, f"Cannot fetch state for {event.id}")
 
             # Refresh HDD data
             try:

--- a/custom_components/hikvision_next/diagnostics.py
+++ b/custom_components/hikvision_next/diagnostics.py
@@ -77,6 +77,14 @@ async def _async_get_diagnostics(
     # Add raw supported events
     info.update(await get_isapi_data("RAW Events Info", isapi.isapi.Event.triggers))
 
+    # Add IO info - direct connected
+    info.update(await get_isapi_data("Direct IO Inputs", isapi.isapi.System.IO.inputs))
+    info.update(await get_isapi_data("Direct IO Outputs", isapi.isapi.System.IO.outputs))
+
+    # Add IO info - proxy connected
+    info.update(await get_isapi_data("Proxied IO Inputs", isapi.isapi.ContentMgmt.IOProxy.inputs))
+    info.update(await get_isapi_data("Proxied IO Outputs", isapi.isapi.ContentMgmt.IOProxy.outputs))
+
     # Add raw streams info
     info.update(await get_isapi_data("RAW Streams Info", isapi.isapi.Streaming.channels))
 

--- a/custom_components/hikvision_next/diagnostics.py
+++ b/custom_components/hikvision_next/diagnostics.py
@@ -63,44 +63,28 @@ async def _async_get_diagnostics(
     info.update({"Entity Data": to_json(coordinator.data)})
 
     # Add raw device info
-    info.update(await get_isapi_data("RAW Device Info", isapi.isapi.System.deviceInfo, "DeviceInfo"))
+    info.update(await get_isapi_data("RAW Device Info", isapi.isapi.System.deviceInfo))
 
-    # Add raw camera info
-    info.update(
-        await get_isapi_data(
-            "RAW Analog Camera Info",
-            isapi.isapi.System.Video.inputs.channels,
-            "VideoInputChannelList",
-        )
-    )
-    info.update(
-        await get_isapi_data(
-            "RAW IP Camera Info",
-            isapi.isapi.ContentMgmt.InputProxy.channels,
-            "InputProxyChannelList",
-        )
-    )
+    # Add raw camera info - Direct connected
+    info.update(await get_isapi_data("RAW Analog Camera Info", isapi.isapi.System.Video.inputs.channels))
+
+    # Add raw camera info - Proxy connected
+    info.update(await get_isapi_data("RAW IP Camera Info", isapi.isapi.ContentMgmt.InputProxy.channels))
 
     # Add raw capabilities
-    info.update(await get_isapi_data("RAW Capabilities Info", isapi.isapi.System.capabilities, "DeviceCap"))
+    info.update(await get_isapi_data("RAW Capabilities Info", isapi.isapi.System.capabilities))
 
     # Add raw supported events
-    info.update(await get_isapi_data("RAW Events Info", isapi.isapi.Event.triggers, ""))
+    info.update(await get_isapi_data("RAW Events Info", isapi.isapi.Event.triggers))
 
     # Add raw streams info
-    info.update(await get_isapi_data("RAW Streams Info", isapi.isapi.Streaming.channels, "StreamingChannelList"))
+    info.update(await get_isapi_data("RAW Streams Info", isapi.isapi.Streaming.channels))
 
     # Add raw holiday info
-    info.update(await get_isapi_data("RAW Holiday Info", isapi.isapi.System.Holidays, "HolidayList"))
+    info.update(await get_isapi_data("RAW Holiday Info", isapi.isapi.System.Holidays))
 
     # Add alarms server info
-    info.update(
-        await get_isapi_data(
-            "RAW Alarm Server Info",
-            isapi.isapi.Event.notification.httpHosts,
-            "HttpHostNotificationList",
-        )
-    )
+    info.update(await get_isapi_data("RAW Alarm Server Info", isapi.isapi.Event.notification.httpHosts))
 
     return info
 


### PR DESCRIPTION
@maciej-or , apologies, I hadn't realised you merged the last PR.  I was going to add to it - should have probably pulled it or at least made that clear.

This is an improved version of IO support that fits much better in the general method of event management without using different binary sensors or switches.  It will also allow simple adding of other NVR/Single camera event management going forward.

**Other enhancements**
1. Added connection type to camera object (direct or proxied)
2. Used this connection type instead of looking for whether NVR or single camera and whether analog or IP.  Simplifies some of the functions greatly.  Single IP camera or NVR analog camera are all direct, IP camera via NVR are proxied.  This fits with the ISAPI API path logic.
3. Added a couple of event definition options to support different node keys depending on whether direct or proxied camera (you will see in the IO event definition in const.py)  Note:  I haven't looked at whether this should be applied to other definitions yet.  It may or not make sense to simplify some of the isapi functions.
4. Added a get_event_state_node funtion to utilise these 2 new event definition keys and return correct node to query.  Used this in existing functions (get/set event enabled state) to simplify down.
5. This now supports Input events via NVR, single IP camera and (should support but not able to test) IP Camera on NVR
6. I have also added more items and ensured the raw outputs are full outputs in the diagnostics download to help with compatibility issues.

Outstanding To Do:
1. It only supports output ports on NVR or single IP cam (direct connect devices).  Need to work more on how this works for proxied cameras.  However, this maybe better as another PR.