### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,4 @@ Download logs from `Settings / System / Logs`
 - DS-2CD2T87G2-L
 - DS-2CD2T87G2P-LSU/SL
 - DS-2DE4425IW-DE (PTZ)
+- Annke C800 (I91BM)


### PR DESCRIPTION
Tested successfully with Annke C800 turret camera, exact model I91BM. Probably works on other C800 variants. Onvif integration in HA for the same camera must be disabled for this one to work. Motion detection switch works, motion sensor works, main and sub streams as camera entities work.