### PR TITLE
alternate url for still images

### DIFF
--- a/custom_components/hikvision_next/camera.py
+++ b/custom_components/hikvision_next/camera.py
@@ -53,8 +53,4 @@ class HikvisionCamera(Camera):
 
     async def async_camera_image(self, width: int | None = None, height: int | None = None) -> bytes | None:
         """Return a still image response from the camera."""
-        data = await self.isapi.get_camera_image(self.stream_info, width, height)
-        if data.startswith(b'<?xml '):
-            # retry if got XML error response
-            data = await self.isapi.get_camera_image(self.stream_info, width, height)
-        return data
+        return await self.isapi.get_camera_image(self.stream_info, width, height)

--- a/custom_components/hikvision_next/config_flow.py
+++ b/custom_components/hikvision_next/config_flow.py
@@ -79,8 +79,8 @@ class HikvisionFlowHandler(ConfigFlow, domain=DOMAIN):
             except ConnectTimeout:
                 errors["base"] = "cannot_connect"
             except Exception as ex:  # pylint: disable=broad-except
-                _LOGGER.error("Unexpected exception %s", ex)
-                errors["base"] = f"Unexpected exception: {ex}"
+                _LOGGER.error("Unexpected %s %s", {type(ex).__name__}, ex)
+                errors["base"] = f"Unexpected {type(ex).__name__}: {ex}"
             else:
                 return self.async_create_entry(title=isapi.device_info.name, data=user_input)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,4 +114,5 @@ async def init_integration(respx_mock, request, mock_isapi, hass: HomeAssistant,
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
+    mock_config_entry.title = model
     return mock_config_entry

--- a/tests/fixtures/ISAPI/Streaming.channels.x0y.picture/badXmlContent.xml
+++ b/tests/fixtures/ISAPI/Streaming.channels.x0y.picture/badXmlContent.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResponseStatus version="1.0"
+  xmlns="http://www.hikvision.com/ver20/XMLSchema">
+  <requestURL>/ISAPI/Streaming/channels/101/picture</requestURL>
+  <statusCode>6</statusCode>
+  <statusString>Invalid XML Content</statusString>
+  <subStatusCode>badXmlContent</subStatusCode>
+</ResponseStatus>

--- a/tests/fixtures/ISAPI/Streaming.channels.x0y.picture/deviceError.xml
+++ b/tests/fixtures/ISAPI/Streaming.channels.x0y.picture/deviceError.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResponseStatus version="2.0"
+  xmlns="http://www.isapi.org/ver20/XMLSchema">
+  <statusCode>3</statusCode>
+  <statusString>Device Error</statusString>
+  <subStatusCode>deviceError</subStatusCode>
+</ResponseStatus>

--- a/tests/fixtures/devices/DS-7616NI-Q2.json
+++ b/tests/fixtures/devices/DS-7616NI-Q2.json
@@ -1,0 +1,4091 @@
+{
+  "data": {
+      "ISAPI": {
+         "System/deviceInfo": {
+            "response": {
+               "DeviceInfo": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "deviceName": "Network Video Recorder",
+                  "deviceID": "48453236-3830-0000-0000-00df00d00000",
+                  "model": "DS-7616NI-Q2/16P",
+                  "serialNumber": "DS-7616NI-Q2/00P0000000000CCRRE00000000WCVU",
+                  "macAddress": "52:a7:c0:3b:a5:10",
+                  "firmwareVersion": "V4.30.097",
+                  "firmwareReleasedDate": "build 240401",
+                  "encoderVersion": "V5.0",
+                  "encoderReleasedDate": "build 210406",
+                  "deviceType": "NVR",
+                  "telecontrolID": "255"
+               }
+            }
+         },
+         "System/capabilities": {
+            "response": {
+               "DeviceCap": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "SysCap": {
+                     "isSupportDst": "true",
+                     "NetworkCap": {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "isSupportWireless": "false",
+                        "isSupportWAN": "false",
+                        "isSupportPPPoE": "true",
+                        "isSupportBond": "false",
+                        "isSupport802_1x": "true",
+                        "isSupportNtp": "true",
+                        "isSupportFtp": "false",
+                        "isSupportUpnp": "true",
+                        "isSupportPNP": "false",
+                        "isSupportDdns": "true",
+                        "isSupportHttps": "true",
+                        "SnmpCap": {
+                           "isSupport": "false"
+                        },
+                        "isSupportExtNetCfg": "true",
+                        "isSupportNetPreviewStrategy": "true",
+                        "isSupportEZVIZ": "true",
+                        "GB28181Cap": {
+                           "isSupportGB28181Service": "false"
+                        },
+                        "VerificationCodeModification": {
+                           "verificationCodeType": {
+                              "@opt": "normal,empty",
+                              "#text": "normal"
+                           },
+                           "isSupportDeclarationURL": "true",
+                           "isSupportPrivacyPolicyURL": "true",
+                           "verificationCodeModify": "true",
+                           "Hyperlinks": {
+                              "declarationURL": "https://www.hik-connect.com/views/terms/termsofservice.html",
+                              "privacyPolicyURL": "https://www.hik-connect.com/views/terms/privacypolicy.html"
+                           },
+                           "isSupportVerificationCodeCheck": "true"
+                        },
+                        "isSupportIntegrate": "true",
+                        "isSupportEZVIZTiming": "true",
+                        "isSupportResourceStatistics": "true",
+                        "isSupportPOEPortsDisableAdaptiveServer": "true",
+                        "isSupportGetLinkSocketIP": "true"
+                     },
+                     "IOCap": {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "IOInputPortNums": "4",
+                        "IOOutputPortNums": "1",
+                        "isSupportIOOutputAdvanceParameter": "false",
+                        "isSupportSetAllIOOutput": "true",
+                        "enabledIOOutputPortNums": "1"
+                     },
+                     "SerialCap": {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "rs485PortNums": "0",
+                        "rs422PortNums": "0",
+                        "rs232PortNums": "0",
+                        "supportRS232Config": "false"
+                     },
+                     "VideoCap": {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "videoInputPortNums": "0",
+                        "videoOutputPortNums": "2",
+                        "menuNums": "1"
+                     },
+                     "AudioCap": {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "audioInputNums": "1",
+                        "audioOutputNums": "1"
+                     },
+                     "isSupportHolidy": "true",
+                     "RebootConfigurationCap": {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "RTSP": "true",
+                        "HTTP": "true"
+                     },
+                     "isSupportSimpleDevStatus": "true",
+                     "isSupportFlexible": "true",
+                     "isSupportTimeCap": "true"
+                  },
+                  "voicetalkNums": "2",
+                  "isSupportSnapshot": "false",
+                  "SecurityCap": {
+                     "@version": "1.0",
+                     "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                     "supportUserNums": "32",
+                     "userBondIpNums": "1",
+                     "userBondMacNums": "1",
+                     "isSupportOnlineUser": "true",
+                     "securityVersion": {
+                        "@opt": "1"
+                     },
+                     "keyIterateNum": "100",
+                     "isSupportUserCheck": "true",
+                     "isSupportGetOnlineUserListSC": "false",
+                     "RSAKeyLength": {
+                        "@opt": "512,1024,2048",
+                        "@def": "2048"
+                     },
+                     "WebCertificateCap": {
+                        "CertificateType": {
+                           "@opt": "digest,digest/basic",
+                           "#text": "digest"
+                        }
+                     },
+                     "isSupportConfigFileImport": "true",
+                     "isSupportConfigFileExport": "true",
+                     "cfgFileSecretKeyLenLimit": {
+                        "@min": "1",
+                        "@max": "16"
+                     },
+                     "isSupportPictureURlCertificate": {
+                        "@opt": "true,false",
+                        "#text": "false"
+                     },
+                     "isSupportResetChannelPassword": "false"
+                  },
+                  "EventCap": {
+                     "@version": "1.0",
+                     "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                     "isSupportHDFull": "true",
+                     "isSupportHDError": "true",
+                     "isSupportNicBroken": "true",
+                     "isSupportIpConflict": "true",
+                     "isSupportIllAccess": "true",
+                     "isSupportViException": "false",
+                     "isSupportViMismatch": "false",
+                     "isSupportRecordException": "true",
+                     "isSupportRaidException": "false",
+                     "isSupportViResMismatch": "false",
+                     "isSupportPOCException": "false",
+                     "isSupportSpareException": "false",
+                     "isSupportHumanRecognition": "false",
+                     "isSupportFaceSnap": "true",
+                     "isSupportTriggerCapCheck": "true"
+                  },
+                  "RacmCap": {
+                     "@version": "1.0",
+                     "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                     "isSupportZeroChan": "true",
+                     "inputProxyNums": "16",
+                     "eSATANums": "0",
+                     "miniSASNums": "0",
+                     "nasNums": "8",
+                     "ipSanNums": "8",
+                     "isSupportRaid": "false",
+                     "isSupportExtHdCfg": "true",
+                     "isSupportLogDataPackage": "false",
+                     "isSupportTransCode": "false",
+                     "isSupportIpcImport": "true",
+                     "isSupportIpcStreamType": "true",
+                     "isSupportIOInputProxy": "true",
+                     "isSupportIOOutputProxy": "true",
+                     "isSupportPTZRs485Proxy": "true",
+                     "isSupportSMARTTest": "true",
+                     "pictureSearchType": {
+                        "@opt": "allPic,fireDetection,thermometryAlarm"
+                     },
+                     "recordSearchType": {
+                        "@opt": "CMR,MOTION,ALARM,EDR,ALARMANDMOTION,Command,manual,AllEvent"
+                     },
+                     "isSupportActivateIpc": "true",
+                     "isSupportCheckIpcSecurity": {
+                        "isSupportCheckPassword": "true"
+                     },
+                     "isSupportSyncIPCPassword": "true",
+                     "isSupportTransferIPC": "true",
+                     "isSupportMainAndSubRecord": "false",
+                     "isSupportSmartSearch": "true",
+                     "isSupportPOS": "false",
+                     "isSupportLinkNum": "true",
+                     "ExternalDevice": {
+                        "USB": {
+                           "debugLogOutput": "true",
+                           "isSupportCapturePackage": "false",
+                           "isSupportStreamStorage": "true"
+                        }
+                     },
+                     "customProtocolNums": "16",
+                     "isSupportIPCTiming": "false",
+                     "isSupportWebPrivatePlaybackByUTC": "true",
+                     "isSupportFindCommonFileByUTC": "true",
+                     "isSupportFindEventFileByUTC": "true",
+                     "isSupportSmartSearchRecordByUTC": "true",
+                     "isSupportMRDSearchByTimeZone": "true",
+                     "isSupportSearchRecordLabelByUTC": "true",
+                     "isSupportSearchPictureByUTC": "true",
+                     "isSupportSmartSearchPictureByUTC": "true",
+                     "isSupportFindLogByUTC": "true",
+                     "isSupportUploadRecordByUTC": "true",
+                     "isSupportPlaybackByUTC": "true",
+                     "isSupportFaceDetecttionAlarmByTimeZone": "true",
+                     "isSupportRecordSearchByTargetType": "true",
+                     "securityLogServer": {
+                        "isSupportLogServer": "true"
+                     }
+                  },
+                  "PTZCtrlCap": {
+                     "@version": "1.0",
+                     "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                     "isSupportPatrols": "true"
+                  },
+                  "SmartCap": {
+                     "@version": "1.0",
+                     "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                     "isSupportROI": "false",
+                     "isSupportFaceDetect": "true",
+                     "isSupportIntelliTrace": "false",
+                     "isSupportFieldDetection": "true",
+                     "isSupportDefocusDetection": "true",
+                     "isSupportAudioDetection": "true",
+                     "isSupportSceneChangeDetection": "true",
+                     "isSupportLineDetection": "true",
+                     "isSupportRegionEntrance": "true",
+                     "isSupportRegionExiting": "true",
+                     "isSupportLoitering": "false",
+                     "isSupportGroup": "false",
+                     "isSupportRapidMove": "false",
+                     "isSupportParking": "false",
+                     "isSupportUnattendedBaggage": "true",
+                     "isSupportAttendedBaggage": "true"
+                  },
+                  "isSupportEhome": "true",
+                  "isSupportStreamingEncrypt": "true",
+                  "TestCap": {
+                     "isSupportEmailTest": "true"
+                  },
+                  "ThermalCap": {
+                     "@version": "1.0",
+                     "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                     "isSupportFireDetection": "true",
+                     "isSupportThermometry": "true",
+                     "isSupportRealtimeThermometry": "true",
+                     "isSupportNVR": "true",
+                     "isSupportThermometrySchedule": "true",
+                     "isSupportTemperatureSchedule": "false",
+                     "isSupportFireDetectionSchedule": "true"
+                  },
+                  "isSupportGetmutexFuncErrMsg": "false",
+                  "isSupportTokenAuthenticate": [
+                     "true",
+                     "true"
+                  ],
+                  "isSupportStreamDualVCA": "true",
+                  "isSupportChannelEventCap": "true",
+                  "isSupportSubscribeEvent": "true",
+                  "isSupportDiagnosedData": "false",
+                  "isSupportDiagnosedDataParameter": "false",
+                  "isSupportPictureServer": "true",
+                  "isSupportInputProxyDeviceInfo": "true",
+                  "isSupportEzvizIOAlarmByChannel": "true"
+               }
+            }
+         },
+         "System/IO/inputs/1/status": {
+            "response": {
+               "IOPortStatus": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "ioPortID": "1",
+                  "ioPortType": "input",
+                  "ioState": "inactive"
+               }
+            }
+         },
+         "System/IO/outputs/1/status": {
+            "response": {
+               "IOPortStatus": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "ioPortID": "1",
+                  "ioPortType": "output",
+                  "ioState": "inactive"
+               }
+            }
+         },
+         "System/Holidays": {
+            "response": {
+               "HolidayList": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "holiday": [
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "1",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday1",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "2",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday2",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "3",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday3",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "4",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday4",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "5",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday5",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "6",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday6",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "7",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday7",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "8",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday8",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "9",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday9",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "10",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday10",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "11",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday11",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "12",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday12",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "13",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday13",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "14",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday14",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "15",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday15",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "16",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday16",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "17",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday17",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "18",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday18",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "19",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday19",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "20",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday20",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "21",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday21",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "22",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday22",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "23",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday23",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "24",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday24",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "25",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday25",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "26",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday26",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "27",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday27",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "28",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday28",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "29",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday29",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "30",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday30",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "31",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday31",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "32",
+                        "enabled": {
+                           "@opt": "true,false",
+                           "#text": "false"
+                        },
+                        "holidayName": "Holiday32",
+                        "holidayMode": {
+                           "@opt": "date,week,month",
+                           "#text": "month"
+                        },
+                        "holidayMonth": {
+                           "startMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           },
+                           "endMonth": {
+                              "monthOfYear": "1",
+                              "dayOfMonth": "1"
+                           }
+                        }
+                     }
+                  ]
+               }
+            }
+         },
+         "System/Video/inputs/channels": {
+            "status_code": 403
+         },
+         "ContentMgmt/InputProxy/channels": {
+            "response": {
+               "InputProxyChannelList": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "@size": "7",
+                  "InputProxyChannel": [
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "1",
+                        "name": "Garage",
+                        "sourceInputPortDescriptor": {
+                           "proxyProtocol": "HIKVISION",
+                           "addressingFormatType": "ipaddress",
+                           "ipAddress": "1.0.0.49",
+                           "managePortNo": "8000",
+                           "srcInputPort": "1",
+                           "userName": "admin",
+                           "connMode": "plugplay",
+                           "streamType": "auto",
+                           "deviceID": null
+                        },
+                        "enableAnr": "true"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "2",
+                        "name": "Driveway",
+                        "sourceInputPortDescriptor": {
+                           "proxyProtocol": "HIKVISION",
+                           "addressingFormatType": "ipaddress",
+                           "ipAddress": "1.0.0.73",
+                           "managePortNo": "8000",
+                           "srcInputPort": "1",
+                           "userName": "admin",
+                           "connMode": "plugplay",
+                           "streamType": "auto",
+                           "deviceID": null
+                        },
+                        "enableAnr": "false"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "3",
+                        "name": "Side Yard",
+                        "sourceInputPortDescriptor": {
+                           "proxyProtocol": "HIKVISION",
+                           "addressingFormatType": "ipaddress",
+                           "ipAddress": "1.0.0.123",
+                           "managePortNo": "8000",
+                           "srcInputPort": "1",
+                           "userName": "admin",
+                           "connMode": "plugplay",
+                           "streamType": "auto",
+                           "deviceID": null
+                        },
+                        "enableAnr": "false"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "4",
+                        "name": "Front Door",
+                        "sourceInputPortDescriptor": {
+                           "proxyProtocol": "HIKVISION",
+                           "addressingFormatType": "ipaddress",
+                           "ipAddress": "1.0.0.66",
+                           "managePortNo": "8000",
+                           "srcInputPort": "1",
+                           "userName": "admin",
+                           "connMode": "plugplay",
+                           "streamType": "auto",
+                           "deviceID": null
+                        },
+                        "enableAnr": "false"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "5",
+                        "name": "Front Walkway",
+                        "sourceInputPortDescriptor": {
+                           "proxyProtocol": "HIKVISION",
+                           "addressingFormatType": "ipaddress",
+                           "ipAddress": "1.0.0.92",
+                           "managePortNo": "8000",
+                           "srcInputPort": "1",
+                           "userName": "admin",
+                           "connMode": "plugplay",
+                           "streamType": "auto",
+                           "deviceID": null
+                        },
+                        "enableAnr": "false"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "6",
+                        "name": "Gate",
+                        "sourceInputPortDescriptor": {
+                           "proxyProtocol": "HIKVISION",
+                           "addressingFormatType": "ipaddress",
+                           "ipAddress": "1.0.0.30",
+                           "managePortNo": "8000",
+                           "srcInputPort": "1",
+                           "userName": "admin",
+                           "connMode": "manual",
+                           "streamType": "auto",
+                           "deviceID": null
+                        },
+                        "enableAnr": "false"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "7",
+                        "name": "Lower Patio",
+                        "sourceInputPortDescriptor": {
+                           "proxyProtocol": "HIKVISION",
+                           "addressingFormatType": "ipaddress",
+                           "ipAddress": "1.0.0.238",
+                           "managePortNo": "8000",
+                           "srcInputPort": "1",
+                           "userName": "admin",
+                           "connMode": "manual",
+                           "streamType": "auto",
+                           "deviceID": null
+                        },
+                        "enableAnr": "false"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "8",
+                        "name": "Back Yard",
+                        "sourceInputPortDescriptor": {
+                           "proxyProtocol": "HIKVISION",
+                           "addressingFormatType": "ipaddress",
+                           "ipAddress": "1.0.0.50",
+                           "managePortNo": "8000",
+                           "srcInputPort": "1",
+                           "userName": "admin",
+                           "connMode": "plugplay",
+                           "streamType": "auto",
+                           "deviceID": null
+                        },
+                        "enableAnr": "false"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "9",
+                        "name": "Back Path",
+                        "sourceInputPortDescriptor": {
+                           "proxyProtocol": "HIKVISION",
+                           "addressingFormatType": "ipaddress",
+                           "ipAddress": "1.0.0.149",
+                           "managePortNo": "8000",
+                           "srcInputPort": "1",
+                           "userName": "admin",
+                           "connMode": "manual",
+                           "streamType": "auto",
+                           "deviceID": null
+                        },
+                        "enableAnr": "false"
+                     }
+                  ]
+               }
+            }
+         },
+         "ContentMgmt/Storage": {
+            "response": {
+               "storage": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "hddList": {
+                     "hdd": {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "1",
+                        "hddName": "hdd1",
+                        "hddPath": null,
+                        "hddType": "SATA",
+                        "status": "ok",
+                        "capacity": "1907729",
+                        "freeSpace": "1325056",
+                        "property": "RW"
+                     }
+                  },
+                  "nasList": null,
+                  "workMode": "quota"
+               }
+            }
+         },
+         "Security/adminAccesses": {
+            "response": {
+               "AdminAccessProtocolList": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "AdminAccessProtocol": [
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "1",
+                        "enabled": "true",
+                        "protocol": "HTTP",
+                        "portNo": "80"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "2",
+                        "enabled": "true",
+                        "protocol": "RTSP",
+                        "portNo": "554"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "3",
+                        "enabled": "true",
+                        "protocol": "HTTPS",
+                        "portNo": "443"
+                     },
+                     {
+                        "@version": "1.0",
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "id": "4",
+                        "protocol": "DEV_MANAGE",
+                        "portNo": "8000"
+                     }
+                  ]
+               }
+            }
+         },
+         "Event/triggers": {
+            "response": {
+               "EventTriggerList": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "EventTrigger": [
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "IO-1",
+                        "eventType": "IO",
+                        "inputIOPortID": "1",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "IO-2",
+                        "eventType": "IO",
+                        "inputIOPortID": "2",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "IO-3",
+                        "eventType": "IO",
+                        "inputIOPortID": "3",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "IO-4",
+                        "eventType": "IO",
+                        "inputIOPortID": "4",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "VMD-1",
+                        "eventType": "VMD",
+                        "dynVideoInputChannelID": "1",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-1",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "1"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "VMD-2",
+                        "eventType": "VMD",
+                        "dynVideoInputChannelID": "2",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-2",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "2"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "VMD-3",
+                        "eventType": "VMD",
+                        "dynVideoInputChannelID": "3",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-3",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "3"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "VMD-4",
+                        "eventType": "VMD",
+                        "dynVideoInputChannelID": "4",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-4",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "4"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "VMD-5",
+                        "eventType": "VMD",
+                        "dynVideoInputChannelID": "5",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-5",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "5"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "VMD-6",
+                        "eventType": "VMD",
+                        "dynVideoInputChannelID": "6",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-6",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "6"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "VMD-7",
+                        "eventType": "VMD",
+                        "dynVideoInputChannelID": "7",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-7",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "7"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "VMD-8",
+                        "eventType": "VMD",
+                        "dynVideoInputChannelID": "8",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-8",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "8"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "VMD-9",
+                        "eventType": "VMD",
+                        "dynVideoInputChannelID": "9",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-9",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "9"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "tamper-1",
+                        "eventType": "tamperdetection",
+                        "dynVideoInputChannelID": "1",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "tamper-2",
+                        "eventType": "tamperdetection",
+                        "dynVideoInputChannelID": "2",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "tamper-3",
+                        "eventType": "tamperdetection",
+                        "dynVideoInputChannelID": "3",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "tamper-4",
+                        "eventType": "tamperdetection",
+                        "dynVideoInputChannelID": "4",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "tamper-5",
+                        "eventType": "tamperdetection",
+                        "dynVideoInputChannelID": "5",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "tamper-6",
+                        "eventType": "tamperdetection",
+                        "dynVideoInputChannelID": "6",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "tamper-7",
+                        "eventType": "tamperdetection",
+                        "dynVideoInputChannelID": "7",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "tamper-8",
+                        "eventType": "tamperdetection",
+                        "dynVideoInputChannelID": "8",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "tamper-9",
+                        "eventType": "tamperdetection",
+                        "dynVideoInputChannelID": "9",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "videoloss-1",
+                        "eventType": "videoloss",
+                        "dynVideoInputChannelID": "1",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "videoloss-2",
+                        "eventType": "videoloss",
+                        "dynVideoInputChannelID": "2",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "videoloss-3",
+                        "eventType": "videoloss",
+                        "dynVideoInputChannelID": "3",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "videoloss-4",
+                        "eventType": "videoloss",
+                        "dynVideoInputChannelID": "4",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "videoloss-5",
+                        "eventType": "videoloss",
+                        "dynVideoInputChannelID": "5",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "videoloss-6",
+                        "eventType": "videoloss",
+                        "dynVideoInputChannelID": "6",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "videoloss-7",
+                        "eventType": "videoloss",
+                        "dynVideoInputChannelID": "7",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "videoloss-8",
+                        "eventType": "videoloss",
+                        "dynVideoInputChannelID": "8",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "videoloss-9",
+                        "eventType": "videoloss",
+                        "dynVideoInputChannelID": "9",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "fielddetection-1",
+                        "eventType": "fielddetection",
+                        "dynVideoInputChannelID": "1",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-1",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "1"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "fielddetection-2",
+                        "eventType": "fielddetection",
+                        "dynVideoInputChannelID": "2",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-2",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "2"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "fielddetection-3",
+                        "eventType": "fielddetection",
+                        "dynVideoInputChannelID": "3",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-3",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "3"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "fielddetection-4",
+                        "eventType": "fielddetection",
+                        "dynVideoInputChannelID": "4",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-4",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "4"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "fielddetection-5",
+                        "eventType": "fielddetection",
+                        "dynVideoInputChannelID": "5",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-5",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "5"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "fielddetection-6",
+                        "eventType": "fielddetection",
+                        "dynVideoInputChannelID": "6",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-6",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "6"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "fielddetection-7",
+                        "eventType": "fielddetection",
+                        "dynVideoInputChannelID": "7",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-7",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "7"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "fielddetection-8",
+                        "eventType": "fielddetection",
+                        "dynVideoInputChannelID": "8",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-8",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "8"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "fielddetection-9",
+                        "eventType": "fielddetection",
+                        "dynVideoInputChannelID": "9",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-9",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "9"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "linedetection-1",
+                        "eventType": "linedetection",
+                        "dynVideoInputChannelID": "1",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-1",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "1"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "linedetection-2",
+                        "eventType": "linedetection",
+                        "dynVideoInputChannelID": "2",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "IO-1",
+                                 "notificationMethod": "IO",
+                                 "outputIOPortID": "1"
+                              },
+                              {
+                                 "id": "record-1",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "1"
+                              },
+                              {
+                                 "id": "record-2",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "2"
+                              },
+                              {
+                                 "id": "record-6",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "6"
+                              },
+                              {
+                                 "id": "monitorAlarm",
+                                 "notificationMethod": "monitorAlarm"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "linedetection-3",
+                        "eventType": "linedetection",
+                        "dynVideoInputChannelID": "3",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-3",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "3"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "linedetection-4",
+                        "eventType": "linedetection",
+                        "dynVideoInputChannelID": "4",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-4",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "4"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "linedetection-5",
+                        "eventType": "linedetection",
+                        "dynVideoInputChannelID": "5",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-5",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "5"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "linedetection-6",
+                        "eventType": "linedetection",
+                        "dynVideoInputChannelID": "6",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-6",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "6"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "linedetection-7",
+                        "eventType": "linedetection",
+                        "dynVideoInputChannelID": "7",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-7",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "7"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "linedetection-8",
+                        "eventType": "linedetection",
+                        "dynVideoInputChannelID": "8",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-8",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "8"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "linedetection-9",
+                        "eventType": "linedetection",
+                        "dynVideoInputChannelID": "9",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-9",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "9"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "facedetection-3",
+                        "eventType": "facedetection",
+                        "dynVideoInputChannelID": "3",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-3",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "3"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "facedetection-4",
+                        "eventType": "facedetection",
+                        "dynVideoInputChannelID": "4",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-4",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "4"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "facedetection-5",
+                        "eventType": "facedetection",
+                        "dynVideoInputChannelID": "5",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-5",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "5"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "facedetection-7",
+                        "eventType": "facedetection",
+                        "dynVideoInputChannelID": "7",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "record-7",
+                              "notificationMethod": "record",
+                              "dynVideoInputID": "7"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "facedetection-8",
+                        "eventType": "facedetection",
+                        "dynVideoInputChannelID": "8",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-8",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "8"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "facedetection-9",
+                        "eventType": "facedetection",
+                        "dynVideoInputChannelID": "9",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "record-9",
+                                 "notificationMethod": "record",
+                                 "dynVideoInputID": "9"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "diskfull",
+                        "eventType": "diskfull",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "diskerror",
+                        "eventType": "diskerror",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "beep",
+                              "notificationMethod": "beep"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "nicbroken",
+                        "eventType": "nicbroken",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "ipconflict",
+                        "eventType": "ipconflict",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": {
+                              "id": "beep",
+                              "notificationMethod": "beep"
+                           }
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "illaccess",
+                        "eventType": "illaccess",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema"
+                        }
+                     },
+                     {
+                        "@version": "2.0",
+                        "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                        "id": "recordingfailure",
+                        "eventType": "recordingfailure",
+                        "EventTriggerNotificationList": {
+                           "@version": "2.0",
+                           "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                           "EventTriggerNotification": [
+                              {
+                                 "id": "email",
+                                 "notificationMethod": "email"
+                              },
+                              {
+                                 "id": "center",
+                                 "notificationMethod": "center"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               }
+            }
+         },
+         "Event/notification/httpHosts": {
+            "response": {
+               "HttpHostNotificationList": {
+                  "@version": "1.0",
+                  "@xmlns": "urn:psialliance-org",
+                  "HttpHostNotification": {
+                     "@version": "1.0",
+                     "@xmlns": "urn:psialliance-org",
+                     "id": "1",
+                     "url": "/api/hikvision",
+                     "protocolType": "HTTP",
+                     "parameterFormatType": "XML",
+                     "addressingFormatType": "ipaddress",
+                     "ipAddress": "1.0.0.103",
+                     "portNo": "8123",
+                     "httpAuthenticationMethod": "none",
+                     "Extensions": {
+                        "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                        "intervalBetweenEvents": "0"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/101": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "101",
+                  "channelName": "101",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "1",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "2560",
+                     "videoResolutionHeight": "1440",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "2048",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "true"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/102": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "102",
+                  "channelName": "102",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "1",
+                     "videoCodecType": "H.264",
+                     "videoResolutionWidth": "640",
+                     "videoResolutionHeight": "480",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "75",
+                     "vbrUpperCap": "128",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/103": {
+            "status_code": 403
+         },
+         "Streaming/channels/104": {
+            "status_code": 403
+         },
+         "Streaming/channels/201": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "201",
+                  "channelName": "201",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "2",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "2560",
+                     "videoResolutionHeight": "1440",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "2048",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "true"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/202": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "202",
+                  "channelName": "202",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "2",
+                     "videoCodecType": "H.264",
+                     "videoResolutionWidth": "640",
+                     "videoResolutionHeight": "480",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "128",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/203": {
+            "status_code": 403
+         },
+         "Streaming/channels/204": {
+            "status_code": 403
+         },
+         "Streaming/channels/301": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "301",
+                  "channelName": "301",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "3",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "2560",
+                     "videoResolutionHeight": "1440",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "2048",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/302": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "302",
+                  "channelName": "302",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "3",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "640",
+                     "videoResolutionHeight": "480",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "64",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/303": {
+            "status_code": 403
+         },
+         "Streaming/channels/304": {
+            "status_code": 403
+         },
+         "Streaming/channels/401": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "401",
+                  "channelName": "401",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "4",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "2560",
+                     "videoResolutionHeight": "1440",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "2048",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/402": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "402",
+                  "channelName": "402",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "4",
+                     "videoCodecType": "H.264",
+                     "videoResolutionWidth": "640",
+                     "videoResolutionHeight": "480",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "128",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/403": {
+            "status_code": 403
+         },
+         "Streaming/channels/404": {
+            "status_code": 403
+         },
+         "Streaming/channels/501": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "501",
+                  "channelName": "501",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "5",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "2560",
+                     "videoResolutionHeight": "1440",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "2048",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/502": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "502",
+                  "channelName": "502",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "5",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "640",
+                     "videoResolutionHeight": "480",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "64",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/503": {
+            "status_code": 403
+         },
+         "Streaming/channels/504": {
+            "status_code": 403
+         },
+         "Streaming/channels/601": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "601",
+                  "channelName": "601",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "6",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "2688",
+                     "videoResolutionHeight": "1520",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "2048",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "1000",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "true"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/602": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "602",
+                  "channelName": "602",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "6",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "640",
+                     "videoResolutionHeight": "480",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "64",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/603": {
+            "status_code": 403
+         },
+         "Streaming/channels/604": {
+            "status_code": 403
+         },
+         "Streaming/channels/701": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "701",
+                  "channelName": "701",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "7",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "2560",
+                     "videoResolutionHeight": "1440",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "2048",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/702": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "702",
+                  "channelName": "702",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "7",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "640",
+                     "videoResolutionHeight": "480",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "64",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/703": {
+            "status_code": 403
+         },
+         "Streaming/channels/704": {
+            "status_code": 403
+         },
+         "Streaming/channels/801": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "801",
+                  "channelName": "801",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "8",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "2560",
+                     "videoResolutionHeight": "1440",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "2048",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/802": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "802",
+                  "channelName": "802",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "8",
+                     "videoCodecType": "H.264",
+                     "videoResolutionWidth": "640",
+                     "videoResolutionHeight": "480",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "128",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  }
+               }
+            }
+         },
+         "Streaming/channels/803": {
+            "status_code": 403
+         },
+         "Streaming/channels/804": {
+            "status_code": 403
+         },
+         "Streaming/channels/901": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "901",
+                  "channelName": "901",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "9",
+                     "videoCodecType": "H.265",
+                     "videoResolutionWidth": "3840",
+                     "videoResolutionHeight": "2160",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "2048",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "0",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  },
+                  "Audio": {
+                     "enabled": "false",
+                     "audioInputChannelID": "9",
+                     "audioCompressionType": "G.711ulaw"
+                  }
+               }
+            }
+         },
+         "Streaming/channels/902": {
+            "response": {
+               "StreamingChannel": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "902",
+                  "channelName": "902",
+                  "enabled": "true",
+                  "Transport": {
+                     "ControlProtocolList": {
+                        "ControlProtocol": {
+                           "streamingTransport": "RTSP"
+                        }
+                     }
+                  },
+                  "Video": {
+                     "enabled": "true",
+                     "videoInputChannelID": "9",
+                     "videoCodecType": "H.264",
+                     "videoResolutionWidth": "640",
+                     "videoResolutionHeight": "360",
+                     "videoQualityControlType": "VBR",
+                     "fixedQuality": "60",
+                     "vbrUpperCap": "128",
+                     "vbrLowerCap": "32",
+                     "maxFrameRate": "2000",
+                     "snapShotImageType": "JPEG",
+                     "SmartCodec": {
+                        "enabled": "false"
+                     }
+                  },
+                  "Audio": {
+                     "enabled": "false",
+                     "audioInputChannelID": "9",
+                     "audioCompressionType": "G.711ulaw"
+                  }
+               }
+            }
+         },
+         "Streaming/channels/903": {
+            "status_code": 403
+         },
+         "Streaming/channels/904": {
+            "status_code": 403
+         },
+         "ContentMgmt/InputProxy/channels/1/video/motionDetection": {
+            "response": {
+               "MotionDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "enableHighlight": "false",
+                  "samplingInterval": "5",
+                  "startTriggerTime": "1000",
+                  "endTriggerTime": "1000",
+                  "regionType": "grid",
+                  "Grid": {
+                     "rowGranularity": "15",
+                     "columnGranularity": "22"
+                  },
+                  "MotionDetectionLayout": {
+                     "@version": "2.0",
+                     "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                     "sensitivityLevel": "20",
+                     "layout": {
+                        "gridMap": "00000000030003fff01ffff03ffff0fffffefffffefffffefffffefffffefffffefffffefffffefffffefffffe"
+                     },
+                     "targetType": null
+                  }
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/1/video/tamperDetection": {
+            "response": {
+               "TamperDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "704",
+                     "normalizedScreenHeight": "480"
+                  },
+                  "tampersensitivityLevel": "2",
+                  "TamperDetectionRegionList": null
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/1/video/videoLoss": {
+            "response": {
+               "VideoLoss": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true"
+               }
+            }
+         },
+         "Smart/FieldDetection/1": {
+            "response": {
+               "FieldDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "1",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "FieldDetectionRegionList": {
+                     "FieldDetectionRegion": {
+                        "id": "1",
+                        "sensitivityLevel": "50",
+                        "timeThreshold": "0",
+                        "RegionCoordinatesList": null
+                     }
+                  }
+               }
+            }
+         },
+         "Smart/LineDetection/1": {
+            "response": {
+               "LineDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "1",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "LineItemList": {
+                     "LineItem": {
+                        "id": "1",
+                        "enabled": "true",
+                        "sensitivityLevel": "50",
+                        "directionSensitivity": "any",
+                        "CoordinatesList": {
+                           "Coordinates": [
+                              {
+                                 "positionX": "554",
+                                 "positionY": "883"
+                              },
+                              {
+                                 "positionX": "707",
+                                 "positionY": "0"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  "recogRuleType": "vectorMode"
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/2/video/motionDetection": {
+            "response": {
+               "MotionDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "enableHighlight": "false",
+                  "samplingInterval": "5",
+                  "startTriggerTime": "1000",
+                  "endTriggerTime": "1000",
+                  "regionType": "grid",
+                  "Grid": {
+                     "rowGranularity": "15",
+                     "columnGranularity": "22"
+                  },
+                  "MotionDetectionLayout": {
+                     "@version": "2.0",
+                     "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                     "sensitivityLevel": "20",
+                     "layout": {
+                        "gridMap": "00000000000000000000200000200000e00003f0000ffc00ffff00ffff80ffff80ffff80ffff80ffff80ffff80"
+                     },
+                     "targetType": null
+                  }
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/2/video/tamperDetection": {
+            "response": {
+               "TamperDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "704",
+                     "normalizedScreenHeight": "480"
+                  },
+                  "tampersensitivityLevel": "2",
+                  "TamperDetectionRegionList": null
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/2/video/videoLoss": {
+            "response": {
+               "VideoLoss": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true"
+               }
+            }
+         },
+         "Smart/FieldDetection/2": {
+            "response": {
+               "FieldDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "2",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "FieldDetectionRegionList": {
+                     "FieldDetectionRegion": {
+                        "id": "1",
+                        "sensitivityLevel": "50",
+                        "timeThreshold": "0",
+                        "RegionCoordinatesList": null
+                     }
+                  }
+               }
+            }
+         },
+         "Smart/LineDetection/2": {
+            "response": {
+               "LineDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "2",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "LineItemList": {
+                     "LineItem": {
+                        "id": "1",
+                        "enabled": "true",
+                        "sensitivityLevel": "50",
+                        "directionSensitivity": "any",
+                        "CoordinatesList": {
+                           "Coordinates": [
+                              {
+                                 "positionX": "386",
+                                 "positionY": "788"
+                              },
+                              {
+                                 "positionX": "594",
+                                 "positionY": "763"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  "recogRuleType": "vectorMode"
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/3/video/motionDetection": {
+            "response": {
+               "MotionDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "enableHighlight": "false",
+                  "samplingInterval": "5",
+                  "startTriggerTime": "1000",
+                  "endTriggerTime": "1000",
+                  "regionType": "grid",
+                  "Grid": {
+                     "rowGranularity": "15",
+                     "columnGranularity": "22"
+                  },
+                  "MotionDetectionLayout": {
+                     "@version": "2.0",
+                     "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                     "sensitivityLevel": "20",
+                     "layout": {
+                        "gridMap": "fffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffc"
+                     },
+                     "targetType": null
+                  }
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/3/video/tamperDetection": {
+            "response": {
+               "TamperDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "704",
+                     "normalizedScreenHeight": "480"
+                  },
+                  "tampersensitivityLevel": "2",
+                  "TamperDetectionRegionList": null
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/3/video/videoLoss": {
+            "response": {
+               "VideoLoss": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "false"
+               }
+            }
+         },
+         "Smart/FieldDetection/3": {
+            "response": {
+               "FieldDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "3",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "FieldDetectionRegionList": {
+                     "FieldDetectionRegion": {
+                        "id": "1",
+                        "sensitivityLevel": "50",
+                        "timeThreshold": "0",
+                        "RegionCoordinatesList": null
+                     }
+                  }
+               }
+            }
+         },
+         "Smart/LineDetection/3": {
+            "response": {
+               "LineDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "3",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "LineItemList": {
+                     "LineItem": {
+                        "id": "1",
+                        "enabled": "true",
+                        "sensitivityLevel": "50",
+                        "directionSensitivity": "any",
+                        "CoordinatesList": {
+                           "Coordinates": [
+                              {
+                                 "positionX": "834",
+                                 "positionY": "224"
+                              },
+                              {
+                                 "positionX": "185",
+                                 "positionY": "125"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  "recogRuleType": "vectorMode"
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/4/video/motionDetection": {
+            "response": {
+               "MotionDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "enableHighlight": "false",
+                  "samplingInterval": "5",
+                  "startTriggerTime": "1000",
+                  "endTriggerTime": "1000",
+                  "regionType": "grid",
+                  "Grid": {
+                     "rowGranularity": "15",
+                     "columnGranularity": "22"
+                  },
+                  "MotionDetectionLayout": {
+                     "@version": "2.0",
+                     "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                     "sensitivityLevel": "20",
+                     "layout": {
+                        "gridMap": "00380000380000780000e00000e00000e00021e00067f80067f800603800003800003800001800000000000000"
+                     },
+                     "targetType": null
+                  }
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/4/video/tamperDetection": {
+            "response": {
+               "TamperDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "704",
+                     "normalizedScreenHeight": "480"
+                  },
+                  "tampersensitivityLevel": "2",
+                  "TamperDetectionRegionList": null
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/4/video/videoLoss": {
+            "response": {
+               "VideoLoss": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true"
+               }
+            }
+         },
+         "Smart/FieldDetection/4": {
+            "response": {
+               "FieldDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "4",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "FieldDetectionRegionList": {
+                     "FieldDetectionRegion": {
+                        "id": "1",
+                        "sensitivityLevel": "50",
+                        "timeThreshold": "0",
+                        "RegionCoordinatesList": null
+                     }
+                  }
+               }
+            }
+         },
+         "Smart/LineDetection/4": {
+            "response": {
+               "LineDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "4",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "LineItemList": {
+                     "LineItem": {
+                        "id": "1",
+                        "enabled": "true",
+                        "sensitivityLevel": "50",
+                        "directionSensitivity": "right-left",
+                        "CoordinatesList": {
+                           "Coordinates": [
+                              {
+                                 "positionX": "304",
+                                 "positionY": "554"
+                              },
+                              {
+                                 "positionX": "244",
+                                 "positionY": "324"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  "recogRuleType": "vectorMode"
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/5/video/motionDetection": {
+            "response": {
+               "MotionDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "enableHighlight": "false",
+                  "samplingInterval": "5",
+                  "startTriggerTime": "1000",
+                  "endTriggerTime": "1000",
+                  "regionType": "grid",
+                  "Grid": {
+                     "rowGranularity": "15",
+                     "columnGranularity": "22"
+                  },
+                  "MotionDetectionLayout": {
+                     "@version": "2.0",
+                     "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                     "sensitivityLevel": "20",
+                     "layout": {
+                        "gridMap": "fffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffc"
+                     },
+                     "targetType": null
+                  }
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/5/video/tamperDetection": {
+            "response": {
+               "TamperDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "704",
+                     "normalizedScreenHeight": "480"
+                  },
+                  "tampersensitivityLevel": "2",
+                  "TamperDetectionRegionList": null
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/5/video/videoLoss": {
+            "response": {
+               "VideoLoss": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "false"
+               }
+            }
+         },
+         "Smart/FieldDetection/5": {
+            "response": {
+               "FieldDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "5",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "FieldDetectionRegionList": {
+                     "FieldDetectionRegion": {
+                        "id": "1",
+                        "sensitivityLevel": "50",
+                        "timeThreshold": "0",
+                        "RegionCoordinatesList": null
+                     }
+                  }
+               }
+            }
+         },
+         "Smart/LineDetection/5": {
+            "response": {
+               "LineDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "5",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "LineItemList": {
+                     "LineItem": {
+                        "id": "1",
+                        "enabled": "true",
+                        "sensitivityLevel": "50",
+                        "directionSensitivity": "right-left",
+                        "CoordinatesList": {
+                           "Coordinates": [
+                              {
+                                 "positionX": "523",
+                                 "positionY": "125"
+                              },
+                              {
+                                 "positionX": "994",
+                                 "positionY": "231"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  "recogRuleType": "vectorMode"
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/6/video/motionDetection": {
+            "response": {
+               "MotionDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "enableHighlight": "false",
+                  "samplingInterval": "5",
+                  "startTriggerTime": "1000",
+                  "endTriggerTime": "1000",
+                  "regionType": "grid",
+                  "Grid": {
+                     "rowGranularity": "15",
+                     "columnGranularity": "22"
+                  },
+                  "MotionDetectionLayout": {
+                     "@version": "2.0",
+                     "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                     "sensitivityLevel": "20",
+                     "layout": {
+                        "gridMap": "fffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffc"
+                     },
+                     "targetType": null
+                  }
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/6/video/tamperDetection": {
+            "response": {
+               "TamperDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "false",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "704",
+                     "normalizedScreenHeight": "480"
+                  },
+                  "tampersensitivityLevel": "2",
+                  "TamperDetectionRegionList": null
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/6/video/videoLoss": {
+            "response": {
+               "VideoLoss": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "false"
+               }
+            }
+         },
+         "Smart/FieldDetection/6": {
+            "response": {
+               "FieldDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "6",
+                  "enabled": "false",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "FieldDetectionRegionList": {
+                     "FieldDetectionRegion": {
+                        "id": "1",
+                        "sensitivityLevel": "50",
+                        "timeThreshold": "0",
+                        "RegionCoordinatesList": null
+                     }
+                  }
+               }
+            }
+         },
+         "Smart/LineDetection/6": {
+            "response": {
+               "LineDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "6",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "LineItemList": {
+                     "LineItem": {
+                        "id": "1",
+                        "enabled": "true",
+                        "sensitivityLevel": "50",
+                        "directionSensitivity": "any",
+                        "CoordinatesList": {
+                           "Coordinates": [
+                              {
+                                 "positionX": "271",
+                                 "positionY": "621"
+                              },
+                              {
+                                 "positionX": "896",
+                                 "positionY": "850"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  "recogRuleType": "vectorMode"
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/7/video/motionDetection": {
+            "response": {
+               "MotionDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "enableHighlight": "false",
+                  "samplingInterval": "5",
+                  "startTriggerTime": "1000",
+                  "endTriggerTime": "1000",
+                  "regionType": "grid",
+                  "Grid": {
+                     "rowGranularity": "15",
+                     "columnGranularity": "22"
+                  },
+                  "MotionDetectionLayout": {
+                     "@version": "2.0",
+                     "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                     "sensitivityLevel": "20",
+                     "layout": {
+                        "gridMap": "fffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffcfffffc"
+                     },
+                     "targetType": null
+                  }
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/7/video/tamperDetection": {
+            "response": {
+               "TamperDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "false",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "704",
+                     "normalizedScreenHeight": "480"
+                  },
+                  "tampersensitivityLevel": "2",
+                  "TamperDetectionRegionList": null
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/7/video/videoLoss": {
+            "response": {
+               "VideoLoss": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "false"
+               }
+            }
+         },
+         "Smart/FieldDetection/7": {
+            "response": {
+               "FieldDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "7",
+                  "enabled": "false",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "FieldDetectionRegionList": {
+                     "FieldDetectionRegion": {
+                        "id": "1",
+                        "sensitivityLevel": "50",
+                        "timeThreshold": "0",
+                        "RegionCoordinatesList": null
+                     }
+                  }
+               }
+            }
+         },
+         "Smart/LineDetection/7": {
+            "response": {
+               "LineDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "7",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "LineItemList": {
+                     "LineItem": {
+                        "id": "1",
+                        "enabled": "true",
+                        "sensitivityLevel": "50",
+                        "directionSensitivity": "any",
+                        "CoordinatesList": {
+                           "Coordinates": [
+                              {
+                                 "positionX": "806",
+                                 "positionY": "729"
+                              },
+                              {
+                                 "positionX": "946",
+                                 "positionY": "684"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  "recogRuleType": "vectorMode"
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/8/video/motionDetection": {
+            "response": {
+               "MotionDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "enableHighlight": "false",
+                  "samplingInterval": "5",
+                  "startTriggerTime": "1000",
+                  "endTriggerTime": "1000",
+                  "regionType": "grid",
+                  "Grid": {
+                     "rowGranularity": "15",
+                     "columnGranularity": "22"
+                  },
+                  "MotionDetectionLayout": {
+                     "@version": "2.0",
+                     "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                     "sensitivityLevel": "20",
+                     "layout": {
+                        "gridMap": "000000000000000000fc0000fe0000fe0000f80000f30000df80001fc0007fe0007ff8007ffc007fee007fcec0"
+                     },
+                     "targetType": null
+                  }
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/8/video/tamperDetection": {
+            "response": {
+               "TamperDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "704",
+                     "normalizedScreenHeight": "480"
+                  },
+                  "tampersensitivityLevel": "2",
+                  "TamperDetectionRegionList": null
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/8/video/videoLoss": {
+            "response": {
+               "VideoLoss": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true"
+               }
+            }
+         },
+         "Smart/FieldDetection/8": {
+            "response": {
+               "FieldDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "8",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "FieldDetectionRegionList": {
+                     "FieldDetectionRegion": {
+                        "id": "1",
+                        "sensitivityLevel": "50",
+                        "timeThreshold": "0",
+                        "RegionCoordinatesList": null
+                     }
+                  }
+               }
+            }
+         },
+         "Smart/LineDetection/8": {
+            "response": {
+               "LineDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "8",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "LineItemList": {
+                     "LineItem": {
+                        "id": "1",
+                        "enabled": "true",
+                        "sensitivityLevel": "50",
+                        "directionSensitivity": "any",
+                        "CoordinatesList": {
+                           "Coordinates": [
+                              {
+                                 "positionX": "686",
+                                 "positionY": "112"
+                              },
+                              {
+                                 "positionX": "68",
+                                 "positionY": "222"
+                              }
+                           ]
+                        }
+                     }
+                  },
+                  "recogRuleType": "vectorMode"
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/9/video/motionDetection": {
+            "response": {
+               "MotionDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "enableHighlight": "false",
+                  "samplingInterval": "5",
+                  "startTriggerTime": "1000",
+                  "endTriggerTime": "1000",
+                  "regionType": "grid",
+                  "Grid": {
+                     "rowGranularity": "15",
+                     "columnGranularity": "22"
+                  },
+                  "MotionDetectionLayout": {
+                     "@version": "2.0",
+                     "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                     "sensitivityLevel": "20",
+                     "layout": {
+                        "gridMap": "000000000000000000000000000f00003f00007e0000f80003e00007c0000f80001f00003e0000780000f80000",
+                        "RegionList": {
+                           "Region": {
+                              "id": "1",
+                              "RegionCoordinatesList": {
+                                 "RegionCoordinates": [
+                                    {
+                                       "positionX": "698",
+                                       "positionY": "750"
+                                    },
+                                    {
+                                       "positionX": "692",
+                                       "positionY": "676"
+                                    },
+                                    {
+                                       "positionX": "580",
+                                       "positionY": "641"
+                                    },
+                                    {
+                                       "positionX": "187",
+                                       "positionY": "242"
+                                    },
+                                    {
+                                       "positionX": "245",
+                                       "positionY": "23"
+                                    },
+                                    {
+                                       "positionX": "9",
+                                       "positionY": "23"
+                                    },
+                                    {
+                                       "positionX": "15",
+                                       "positionY": "160"
+                                    },
+                                    {
+                                       "positionX": "484",
+                                       "positionY": "691"
+                                    },
+                                    {
+                                       "positionX": "625",
+                                       "positionY": "750"
+                                    },
+                                    {
+                                       "positionX": "675",
+                                       "positionY": "765"
+                                    }
+                                 ]
+                              }
+                           }
+                        }
+                     },
+                     "targetType": null
+                  }
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/9/video/tamperDetection": {
+            "response": {
+               "TamperDetection": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "704",
+                     "normalizedScreenHeight": "480"
+                  },
+                  "tampersensitivityLevel": "2",
+                  "TamperDetectionRegionList": null
+               }
+            }
+         },
+         "ContentMgmt/InputProxy/channels/9/video/videoLoss": {
+            "response": {
+               "VideoLoss": {
+                  "@version": "2.0",
+                  "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                  "enabled": "true"
+               }
+            }
+         },
+         "Smart/FieldDetection/9": {
+            "response": {
+               "FieldDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "9",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "FieldDetectionRegionList": {
+                     "FieldDetectionRegion": [
+                        {
+                           "id": "1",
+                           "sensitivityLevel": "50",
+                           "timeThreshold": "0",
+                           "detectionTarget": "human",
+                           "RegionCoordinatesList": null
+                        },
+                        {
+                           "id": "2",
+                           "sensitivityLevel": "50",
+                           "timeThreshold": "0",
+                           "detectionTarget": "human",
+                           "RegionCoordinatesList": null
+                        },
+                        {
+                           "id": "3",
+                           "sensitivityLevel": "50",
+                           "timeThreshold": "0",
+                           "detectionTarget": "human",
+                           "RegionCoordinatesList": null
+                        },
+                        {
+                           "id": "4",
+                           "sensitivityLevel": "50",
+                           "timeThreshold": "0",
+                           "detectionTarget": "human",
+                           "RegionCoordinatesList": null
+                        }
+                     ]
+                  }
+               }
+            }
+         },
+         "Smart/LineDetection/9": {
+            "response": {
+               "LineDetection": {
+                  "@version": "1.0",
+                  "@xmlns": "http://www.hikvision.com/ver20/XMLSchema",
+                  "id": "9",
+                  "enabled": "true",
+                  "normalizedScreenSize": {
+                     "normalizedScreenWidth": "1000",
+                     "normalizedScreenHeight": "1000"
+                  },
+                  "LineItemList": {
+                     "LineItem": [
+                        {
+                           "id": "1",
+                           "enabled": "true",
+                           "sensitivityLevel": "50",
+                           "directionSensitivity": "any",
+                           "CoordinatesList": {
+                              "Coordinates": [
+                                 {
+                                    "positionX": "500",
+                                    "positionY": "250"
+                                 },
+                                 {
+                                    "positionX": "288",
+                                    "positionY": "608"
+                                 }
+                              ]
+                           },
+                           "detectionTarget": "human"
+                        },
+                        {
+                           "id": "2",
+                           "enabled": "false",
+                           "sensitivityLevel": "50",
+                           "directionSensitivity": "any",
+                           "CoordinatesList": {
+                              "Coordinates": [
+                                 {
+                                    "positionX": "0",
+                                    "positionY": "1000"
+                                 },
+                                 {
+                                    "positionX": "0",
+                                    "positionY": "1000"
+                                 }
+                              ]
+                           },
+                           "detectionTarget": "human"
+                        },
+                        {
+                           "id": "3",
+                           "enabled": "false",
+                           "sensitivityLevel": "50",
+                           "directionSensitivity": "any",
+                           "CoordinatesList": {
+                              "Coordinates": [
+                                 {
+                                    "positionX": "0",
+                                    "positionY": "1000"
+                                 },
+                                 {
+                                    "positionX": "0",
+                                    "positionY": "1000"
+                                 }
+                              ]
+                           },
+                           "detectionTarget": "human"
+                        },
+                        {
+                           "id": "4",
+                           "enabled": "false",
+                           "sensitivityLevel": "50",
+                           "directionSensitivity": "any",
+                           "CoordinatesList": {
+                              "Coordinates": [
+                                 {
+                                    "positionX": "0",
+                                    "positionY": "1000"
+                                 },
+                                 {
+                                    "positionX": "0",
+                                    "positionY": "1000"
+                                 }
+                              ]
+                           },
+                           "detectionTarget": "human"
+                        }
+                     ]
+                  },
+                  "recogRuleType": "vectorMode"
+               }
+            }
+         }
+      }
+   }
+}

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,11 +1,15 @@
 """Tests for camera platform."""
 
 import pytest
+import respx
+import httpx
 from homeassistant.core import HomeAssistant
 from homeassistant.const import STATE_IDLE
 from homeassistant.components import camera as camera_component
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from tests.conftest import load_fixture
+from tests.conftest import TEST_HOST
 
 
 @pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2"], indirect=True)
@@ -22,3 +26,88 @@ async def test_camera(hass: HomeAssistant, init_integration: MockConfigEntry) ->
     camera_entity = camera_component._get_camera_from_entity_id(hass, entity_id)
     stream_url = await camera_entity.stream_source()
     assert stream_url == "rtsp://u1:%2A%2A%2A@1.0.0.255:10554/Streaming/channels/101"
+
+
+@respx.mock
+@pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2"], indirect=True)
+async def test_camera_snapshot(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test camera snapshot."""
+
+    entity_id = "camera.ds_7608nxi_i0_0p_s0000000000ccrrj00000000wcvu_101"
+    camera_entity = camera_component._get_camera_from_entity_id(hass, entity_id)
+
+    image_url = f"{TEST_HOST}/ISAPI/Streaming/channels/101/picture"
+    respx.get(image_url).respond(content=b"binary image data")
+    image = await camera_entity.async_camera_image()
+    assert image == b"binary image data"
+
+
+@respx.mock
+@pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2"], indirect=True)
+async def test_camera_snapshot_device_error(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test camera snapshot with 2 attempts."""
+
+    entity_id = "camera.ds_7608nxi_i0_0p_s0000000000ccrrj00000000wcvu_101"
+    camera_entity = camera_component._get_camera_from_entity_id(hass, entity_id)
+
+    image_url = f"{TEST_HOST}/ISAPI/Streaming/channels/101/picture"
+    route = respx.get(image_url)
+    error_response = load_fixture("ISAPI/Streaming.channels.x0y.picture", "deviceError")
+    route.side_effect = [
+        httpx.Response(200, content=error_response),
+        httpx.Response(200, content=error_response),
+        httpx.Response(200, content=b"binary image data"),
+    ]
+    image = await camera_entity.async_camera_image()
+    assert image == b"binary image data"
+
+
+@respx.mock
+@pytest.mark.parametrize("init_integration", ["DS-7616NI-Q2"], indirect=True)
+async def test_camera_snapshot_alternate_url(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test camera snapshot with alternate url."""
+
+    entity_id = "camera.ds_7616ni_q2_00p0000000000ccrre00000000wcvu_101"
+    camera_entity = camera_component._get_camera_from_entity_id(hass, entity_id)
+
+    error_response = load_fixture("ISAPI/Streaming.channels.x0y.picture", "badXmlContent")
+    image_url = f"{TEST_HOST}/ISAPI/Streaming/channels/101/picture"
+    respx.get(image_url).respond(content=error_response)
+    image_url = f"{TEST_HOST}/ISAPI/ContentMgmt/StreamingProxy/channels/101/picture"
+    respx.get(image_url).respond(content=b"binary image data")
+    image = await camera_entity.async_camera_image()
+    assert image == b"binary image data"
+
+
+device_data = {
+    "DS-7608NXI-I2": {
+        "entity_id": "camera.ds_7608nxi_i0_0p_s0000000000ccrrj00000000wcvu_101",
+        "codec": "H.264",
+        "width": "3840",
+        "height": "2160",
+        "rtsp_port": 10554,
+    },
+    "DS-7616NI-Q2": {
+        "entity_id": "camera.ds_7616ni_q2_00p0000000000ccrre00000000wcvu_101",
+        "codec": "H.265",
+        "width": "2560",
+        "height": "1440",
+        "rtsp_port": 554,
+    },
+}
+
+
+@pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2", "DS-7616NI-Q2"], indirect=True)
+async def test_camera_stream_info(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test camera snapshot with alternate url."""
+
+    data = device_data[init_integration.title]
+    entity_id = data["entity_id"]
+    camera_entity = camera_component._get_camera_from_entity_id(hass, entity_id)
+
+    assert camera_entity.stream_info.codec == data["codec"]
+    assert camera_entity.stream_info.width == data["width"]
+    assert camera_entity.stream_info.height == data["height"]
+
+    stream_url = await camera_entity.stream_source()
+    assert stream_url == f"rtsp://u1:%2A%2A%2A@1.0.0.255:{data['rtsp_port']}/Streaming/channels/101"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -54,7 +54,7 @@ async def test_wrong_credentials_config_flow(hass, mock_isapi):
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
-    respx.get(f'{TEST_HOST}/ISAPI/System/deviceInfo').respond(status_code=401)
+    respx.get(f"{TEST_HOST}/ISAPI/System/deviceInfo").respond(status_code=401)
     result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=TEST_CONFIG)
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {"base": "invalid_auth"}
@@ -72,4 +72,4 @@ async def test_unexpeced_exception_config_flowget_device_info_mock(get_device_in
     get_device_info_mock.side_effect = Exception("Something went wrong")
     result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=TEST_CONFIG)
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("errors") == {"base": "Unexpected exception: Something went wrong"}
+    assert result.get("errors") == {"base": "Unexpected Exception: Something went wrong"}


### PR DESCRIPTION
solved issue reported in https://github.com/maciej-or/hikvision_next/issues/176
use alternate url ISAPI/ContentMgmt/StreamingProxy/channels/x0y/picture if defualt ISAPI/Streaming/channels/101/picture returns error 6 badXmlContent