### PR TITLE
add user permission in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The scope supported features depends on device model, setup and firmware version
   - Remote: Parameters Settings
   - Remote: Log Search / Interrogate Working Status
   - Remote: Live View
+  - Remote: Notify Surveillance Center / Trigger Alarm Output
 - Events
   - Notify Surveillance Center
   - Regions if needed


### PR DESCRIPTION
Add user permission "Remote: Notify Surveillance Center / Trigger Alarm Output" in Readme 

This solves 403 error when we want to enable the Alarm Output in H.A. for Camera DS-2CD2T46G2-ISU/SL