### PR TITLE
Add thermal camera support (broken with firmware version 5.5.338)

### DIFF
--- a/custom_components/hikvision_next/binary_sensor.py
+++ b/custom_components/hikvision_next/binary_sensor.py
@@ -46,9 +46,15 @@ class EventBinarySensor(BinarySensorEntity):
         """Initialize."""
         self.entity_id = ENTITY_ID_FORMAT.format(event.unique_id)
         self._attr_unique_id = self.entity_id
-        self._attr_translation_key = event.id
-        if event.id == EVENT_IO:
-            self._attr_translation_placeholders = {"io_port_id": event.io_port_id}
         self._attr_device_class = EVENTS[event.id]["device_class"]
         self._attr_device_info = device.hass_device_info(device_id)
         self._attr_entity_registry_enabled_default = not event.disabled
+
+        # For multi-channel devices, add channel suffix to name for clarity
+        if device.capabilities.is_multi_channel and event.channel_id > 0:
+            base_label = EVENTS[event.id]["label"]
+            self._attr_name = f"{base_label} (Ch. {event.channel_id})"
+        else:
+            self._attr_translation_key = event.id
+            if event.id == EVENT_IO:
+                self._attr_translation_placeholders = {"io_port_id": event.io_port_id}

--- a/custom_components/hikvision_next/const.py
+++ b/custom_components/hikvision_next/const.py
@@ -65,4 +65,8 @@ EVENTS = {
         **ISAPI_EVENTS["pir"],
         "device_class": BinarySensorDeviceClass.MOTION,
     },
+    "thermometry": {
+        **ISAPI_EVENTS["thermometry"],
+        "device_class": BinarySensorDeviceClass.HEAT,
+    },
 }

--- a/custom_components/hikvision_next/hikvision_device.py
+++ b/custom_components/hikvision_next/hikvision_device.py
@@ -159,6 +159,8 @@ class HikvisionDevice(ISAPIClient):
             self.entry.async_start_reauth(self.hass)
             error = "Unauthorized access"
         elif isinstance(ex, ISAPIForbiddenError):
+            if getattr(ex, "suppressed", False):
+                return
             error = "Forbidden access"
         elif isinstance(ex, (httpx.TimeoutException, httpx.ConnectTimeout)):
             error = "Timeout"

--- a/custom_components/hikvision_next/hikvision_device.py
+++ b/custom_components/hikvision_next/hikvision_device.py
@@ -119,7 +119,8 @@ class HikvisionDevice(ISAPIClient):
         camera_id: int | None = None,
     ) -> list[EventInfo]:
         """Get events info handled by integration (camera id:  NVR = None, camera > 0)."""
-        events = []
+        events: list[EventInfo] = []
+        events_by_unique_id: dict[str, EventInfo] = {}
 
         if camera_id is None:  # NVR
             integration_supported_events = [
@@ -137,9 +138,30 @@ class HikvisionDevice(ISAPIClient):
             unique_id = f"{slugify(self.device_info.serial_no.lower())}{device_id_param}{io_port_id_param}_{event.id}"
 
             if EVENTS.get(event.id):
-                event.unique_id = unique_id
-                event.disabled = "center" not in event.notifications  # Disable if not set Notify Surveillance Center
-                events.append(event)
+                notifications = list(event.notifications)
+                disabled = "center" not in notifications  # Disable if not set Notify Surveillance Center
+                event_info = EventInfo(
+                    id=event.id,
+                    channel_id=event.channel_id,
+                    io_port_id=event.io_port_id,
+                    unique_id=unique_id,
+                    url=event.url,
+                    is_proxy=event.is_proxy,
+                    disabled=disabled,
+                    notifications=notifications,
+                )
+
+                if existing := events_by_unique_id.get(unique_id):
+                    merged_notifications = list(dict.fromkeys([*existing.notifications, *event_info.notifications]))
+                    existing.notifications = merged_notifications
+                    existing.disabled = "center" not in merged_notifications
+                    if not existing.url and event_info.url:
+                        existing.url = event_info.url
+                    existing.is_proxy = existing.is_proxy or event_info.is_proxy
+                    continue
+
+                events_by_unique_id[unique_id] = event_info
+                events.append(event_info)
         return events
 
     def handle_exception(self, ex: Exception, details: str = ""):

--- a/custom_components/hikvision_next/isapi/const.py
+++ b/custom_components/hikvision_next/isapi/const.py
@@ -11,6 +11,7 @@ EVENT_BASIC: Final = "basic"
 EVENT_IO: Final = "io"
 EVENT_SMART: Final = "smart"
 EVENT_PIR: Final = "pir"
+EVENT_THERMAL: Final = "thermal"
 EVENTS = {
     "motiondetection": {
         "type": EVENT_BASIC,
@@ -69,6 +70,12 @@ EVENTS = {
         "slug": "WLAlarm/PIR",
         "direct_node": "PIRAlarm",
     },
+    "thermometry": {
+        "type": EVENT_THERMAL,
+        "label": "Thermometry",
+        "slug": "thermometry/basicParam",
+        "direct_node": "ThermometryBasicParam",
+    },
 }
 
 STREAM_TYPE = {
@@ -81,7 +88,6 @@ STREAM_TYPE = {
 
 EVENTS_ALTERNATE_ID = {
     "vmd": "motiondetection",
-    "thermometry": "motiondetection",
     "shelteralarm": "tamperdetection",
     "VMDHumanVehicle": "motiondetection",
 }

--- a/custom_components/hikvision_next/isapi/isapi.py
+++ b/custom_components/hikvision_next/isapi/isapi.py
@@ -308,6 +308,15 @@ class ISAPIClient:
                 if not channel_id:
                     channel_id = int(event_trigger.get("dynVideoInputChannelID", 0))
                     is_proxy = channel_id > 0
+                # Fallback: Extract channel from event ID (e.g., "VMD-1" → 1)
+                # Some firmware versions don't include videoInputChannelID for all events
+                if not channel_id:
+                    event_id_raw = event_trigger.get("id")
+                    if isinstance(event_id_raw, list):
+                        event_id_raw = event_id_raw[0] if event_id_raw else None
+                    if event_id_raw and "-" in str(event_id_raw):
+                        with suppress(ValueError, IndexError):
+                            channel_id = int(str(event_id_raw).rsplit("-", 1)[1])
 
             url = self.get_event_url(event_id, channel_id, io_port, is_proxy)
 
@@ -332,6 +341,34 @@ class ISAPIClient:
         else:
             available_events = deep_get(event_triggers, "EventTriggerList.EventTrigger", [])
 
+        # Build mapping of eventType → original ID prefix for URL construction
+        # e.g., "vmd" → "VMD", "tamperdetection" → "tamper", "thermometry" → "thermometry"
+        # This is needed because ChannelEventCapList uses different names than Event/triggers IDs
+        event_url_prefix_map = {}
+        for event_trigger in available_events:
+            event_type = event_trigger.get("eventType")
+            if isinstance(event_type, list):
+                event_type = event_type[0] if event_type else None
+            if isinstance(event_type, dict):
+                event_type = event_type.get("#text")
+            event_id_raw = event_trigger.get("id")
+            if isinstance(event_id_raw, list):
+                event_id_raw = event_id_raw[0] if event_id_raw else None
+            if isinstance(event_id_raw, dict):
+                event_id_raw = event_id_raw.get("#text")
+            if event_type and event_id_raw:
+                event_type_key = str(event_type)
+                event_id_key = str(event_id_raw)
+                # Extract prefix (e.g., "VMD-1" → "VMD", "thermometry-2" → "thermometry")
+                prefix = event_id_key.rsplit("-", 1)[0] if "-" in event_id_key else event_id_key
+                event_type_lower = event_type_key.lower()
+                event_url_prefix_map[event_type_lower] = prefix
+                # Also map the translated event ID (e.g., "vmd" → "motiondetection")
+                # so that "motiondetection" from ChannelEventCapList can find "VMD" prefix
+                translated_id = EVENTS_ALTERNATE_ID.get(event_type_lower) or EVENTS_ALTERNATE_ID.get(event_type_key)
+                if translated_id and translated_id not in event_url_prefix_map:
+                    event_url_prefix_map[translated_id] = prefix
+
         for event_trigger in available_events:
             if event := create_event_info(event_trigger):
                 events.append(event)
@@ -346,23 +383,45 @@ class ISAPIClient:
                     events.append(event)
 
         # multichannel camera needs to fetch events for each channel
-        if self.capabilities.is_multi_channel:
+        if self.capabilities.is_multi_channel or not event_triggers:
             channels_capabilities = await self.request(GET, "Event/channels/capabilities")
             channel_events = deep_get(channels_capabilities, "ChannelEventCapList.ChannelEventCap", [])
             for event_cap in channel_events:
                 event_types = deep_get(event_cap, "eventType").get("@opt", "").split(",")
                 channel_id = int(event_cap.get("channelID"))
                 for event_type in event_types:
-                    event_id = event_type.lower()
+                    original_id = event_type.lower()
+                    event_id = original_id
                     if event_id in EVENTS_ALTERNATE_ID:
                         event_id = EVENTS_ALTERNATE_ID[event_id]
                     if event_id not in EVENTS:
                         continue
+                    if event_id == EVENT_IO:
+                        continue
                     if not [e for e in events if (e.id == event_id and e.channel_id == channel_id)]:
-                        event_trigger = await self.request(GET, f"Event/triggers/{event_id}-{channel_id}")
+                        # Use the original ID prefix from Event/triggers response if available
+                        # e.g., ChannelEventCapList has "motionDetection" but camera expects "VMD-1"
+                        # Try both the original_id and the translated event_id for lookup
+                        url_prefix = event_url_prefix_map.get(original_id) or event_url_prefix_map.get(event_id, original_id)
+                        event_trigger = await self.request(GET, f"Event/triggers/{url_prefix}-{channel_id}")
                         event_trigger = deep_get(event_trigger, "EventTrigger", {})
                         if event := create_event_info(event_trigger):
                             events.append(event)
+                        elif event_id in EVENTS:
+                            # Fallback: Create event from ChannelEventCapList even if Event/triggers fails
+                            # Some cameras report capabilities but return 403 for Event/triggers/{event}-{channel}
+                            # Yet they still send notifications for these events
+                            url = self.get_event_url(event_id, channel_id, 0, False)
+                            events.append(
+                                EventInfo(
+                                    channel_id=channel_id,
+                                    io_port_id=0,
+                                    id=event_id,
+                                    url=url,
+                                    is_proxy=False,
+                                    notifications=["center"],
+                                )
+                            )
 
         return events
 
@@ -389,6 +448,9 @@ class ISAPIClient:
         elif event_type == EVENT_PIR:
             # ISAPI/WLAlarm/PIR
             url = slug
+        elif event_type == EVENT_THERMAL:
+            # ISAPI/Thermal/channels/{channel_id}/thermometry/basicParam
+            url = f"Thermal/channels/{channel_id}/{slug}"
         else:
             url = f"Smart/{slug}/{channel_id}"
         return url

--- a/custom_components/hikvision_next/isapi/isapi.py
+++ b/custom_components/hikvision_next/isapi/isapi.py
@@ -181,7 +181,7 @@ class ISAPIClient:
                     serial_no = source.get("serialNumber")
                     if not serial_no or self.get_camera_by_serial_no(serial_no):
                         # serial no is not always recognized correcly by NVR
-                        serial_no = f"{self.device_info.serial_no}_{source.get("proxyProtocol")}_{camera_id}"
+                        serial_no = f"{self.device_info.serial_no}_{source.get('proxyProtocol')}_{camera_id}"
 
                     self.cameras.append(
                         IPCamera(
@@ -247,10 +247,47 @@ class ISAPIClient:
             event_type = event_trigger.get("eventType")
             if not event_type:
                 return None
-            event_id = event_type.lower()
-            # Translate to alternate IDs
-            if event_id in EVENTS_ALTERNATE_ID:
-                event_id = EVENTS_ALTERNATE_ID[event_id]
+
+            raw_event_types = event_type if isinstance(event_type, list) else [event_type]
+            event_types: list[str] = []
+            for raw_event_type in raw_event_types:
+                if isinstance(raw_event_type, dict):
+                    raw_event_type = raw_event_type.get("#text")
+                if raw_event_type:
+                    event_types.append(str(raw_event_type))
+
+            if not event_types:
+                return None
+
+            event_id = None
+            for candidate in event_types:
+                if candidate in EVENTS_ALTERNATE_ID:
+                    normalized = EVENTS_ALTERNATE_ID[candidate]
+                else:
+                    normalized = candidate.lower()
+                    if normalized not in EVENTS and "-" in normalized:
+                        prefix = normalized.split("-", 1)[0]
+                        if prefix in EVENTS_ALTERNATE_ID:
+                            normalized = EVENTS_ALTERNATE_ID[prefix]
+                        elif prefix in EVENTS:
+                            normalized = prefix
+                    if normalized in EVENTS_ALTERNATE_ID:
+                        normalized = EVENTS_ALTERNATE_ID[normalized]
+
+                if normalized in EVENTS:
+                    event_id = normalized
+                    break
+
+            if event_id is None:
+                event_id = event_types[0].lower()
+                if event_id not in EVENTS and "-" in event_id:
+                    prefix = event_id.split("-", 1)[0]
+                    if prefix in EVENTS_ALTERNATE_ID:
+                        event_id = EVENTS_ALTERNATE_ID[prefix]
+                    elif prefix in EVENTS:
+                        event_id = prefix
+                if event_id in EVENTS_ALTERNATE_ID:
+                    event_id = EVENTS_ALTERNATE_ID[event_id]
 
             if event_id == EVENT_PIR:
                 is_supported = str_to_bool(deep_get(system_capabilities, "WLAlarmCap.isSupportPIR", False))

--- a/custom_components/hikvision_next/isapi/isapi.py
+++ b/custom_components/hikvision_next/isapi/isapi.py
@@ -21,6 +21,7 @@ from .const import (
     EVENT_BASIC,
     EVENT_IO,
     EVENT_PIR,
+    EVENT_THERMAL,
     EVENTS,
     EVENTS_ALTERNATE_ID,
     GET,

--- a/custom_components/hikvision_next/isapi/isapi.py
+++ b/custom_components/hikvision_next/isapi/isapi.py
@@ -82,6 +82,7 @@ class ISAPIClient:
         self.storage: list[StorageInfo] = []
         self.protocols = ProtocolsInfo()
         self.pending_initialization = False
+        self._forbidden_cache: set[str] = set()
 
     async def get_device_info(self):
         """Get device info."""
@@ -490,7 +491,7 @@ class ISAPIClient:
 
         data = {"function": event_id, "channelID": int(channel_id)}
         url = "System/mutexFunction?format=json"
-        response = await self.request(POST, url, present="json", data=json.dumps(data))
+        response = await self.request(POST, url, present="json", data=json.dumps(data), use_forbidden_cache=False)
         if not response:
             return []
         response = json.loads(response)
@@ -520,14 +521,14 @@ class ISAPIClient:
             mutex_issues = await self.get_event_switch_mutex(event, channel_id)
 
         if not mutex_issues:
-            data = await self.request(GET, event.url)
+            data = await self.request(GET, event.url, use_forbidden_cache=False)
             node = self._get_event_state_node(event)
             new_state = bool_to_str(is_enabled)
             if new_state == data[node]["enabled"]:
                 return
             data[node]["enabled"] = new_state
             xml = xmltodict.unparse(data)
-            await self.request(PUT, event.url, present="xml", data=xml)
+            await self.request(PUT, event.url, present="xml", data=xml, use_forbidden_cache=False)
         else:
             raise ISAPISetEventStateMutexError(event, mutex_issues)
 
@@ -548,7 +549,7 @@ class ISAPIClient:
             data["IOPortData"] = {"outputState": "low"}
 
         xml = xmltodict.unparse(data)
-        await self.request(PUT, f"System/IO/outputs/{port_no}/trigger", present="xml", data=xml)
+        await self.request(PUT, f"System/IO/outputs/{port_no}/trigger", present="xml", data=xml, use_forbidden_cache=False)
 
     async def get_holiday_enabled_state(self, holiday_index=0) -> bool:
         """Get holiday state."""
@@ -560,7 +561,7 @@ class ISAPIClient:
     async def set_holiday_enabled_state(self, is_enabled: bool, holiday_index=0) -> None:
         """Enable or disable holiday, by enable set time span to year starting from today."""
 
-        data = await self.request(GET, "System/Holidays")
+        data = await self.request(GET, "System/Holidays", use_forbidden_cache=False)
         holiday = data["HolidayList"]["holiday"][holiday_index]
         new_state = bool_to_str(is_enabled)
         if new_state == holiday["enabled"]["#text"]:
@@ -576,7 +577,7 @@ class ISAPIClient:
             holiday.pop("holidayWeek", None)
             holiday.pop("holidayMonth", None)
         xml = xmltodict.unparse(data)
-        await self.request(PUT, "System/Holidays", present="xml", data=xml)
+        await self.request(PUT, "System/Holidays", present="xml", data=xml, use_forbidden_cache=False)
 
     def _get_event_notification_host(self, data: Node) -> Node:
         hosts = deep_get(data, "HttpHostNotificationList.HttpHostNotification", [])
@@ -603,7 +604,7 @@ class ISAPIClient:
         """Set event notifications listener server."""
 
         address = urlparse(base_url)
-        data = await self.request(GET, "Event/notification/httpHosts")
+        data = await self.request(GET, "Event/notification/httpHosts", use_forbidden_cache=False)
         if not data:
             return
         host = self._get_event_notification_host(data)
@@ -644,11 +645,11 @@ class ISAPIClient:
         host["httpAuthenticationMethod"] = "none"
 
         xml = xmltodict.unparse(data)
-        await self.request(PUT, "Event/notification/httpHosts", present="xml", data=xml)
+        await self.request(PUT, "Event/notification/httpHosts", present="xml", data=xml, use_forbidden_cache=False)
 
     async def reboot(self):
         """Reboot device."""
-        await self.request(PUT, "System/reboot", present="xml")
+        await self.request(PUT, "System/reboot", present="xml", use_forbidden_cache=False)
 
     @staticmethod
     def parse_event_notification(xml: str) -> AlertInfo:
@@ -772,9 +773,14 @@ class ISAPIClient:
         url: str,
         present: str = "dict",
         data: str = None,
+        *,
+        use_forbidden_cache: bool = True,
     ) -> Any:
         """Send ISAPI request and log response, returns {} if request fails."""
         full_url = self.get_isapi_url(url)
+        cache_key = f"{method} {full_url}"
+        if use_forbidden_cache and not self.pending_initialization and cache_key in self._forbidden_cache:
+            raise ISAPIForbiddenError(url=full_url, method=method, suppressed=True)
         try:
             if not self._auth_method:
                 await self._detect_auth_method()
@@ -787,6 +793,7 @@ class ISAPIClient:
                 timeout=self.timeout,
             )
             response.raise_for_status()
+            self._forbidden_cache.discard(cache_key)
             result = parse_isapi_response(response, present)
             _LOGGER.debug("--- [%s] %s", method, full_url)
             if data:
@@ -797,6 +804,7 @@ class ISAPIClient:
             if ex.response.status_code == HTTPStatus.UNAUTHORIZED:
                 raise ISAPIUnauthorizedError(ex) from ex
             if ex.response.status_code == HTTPStatus.FORBIDDEN and not self.pending_initialization:
+                self._forbidden_cache.add(cache_key)
                 raise ISAPIForbiddenError(ex) from ex
             if self.pending_initialization:
                 # supress http errors during initialization
@@ -848,8 +856,22 @@ class ISAPIUnauthorizedError(Exception):
 class ISAPIForbiddenError(Exception):
     """HTTP Error 403."""
 
-    def __init__(self, ex: HTTPStatusError, *args) -> None:
+    def __init__(
+        self,
+        ex: HTTPStatusError | None = None,
+        *args,
+        url: str | None = None,
+        method: str = GET,
+        suppressed: bool = False,
+    ) -> None:
         """Initialize exception."""
-        self.message = f"Forbidden request {ex.request.url}, check user permissions."
-        self.response = ex.response
-        _LOGGER.warning(self.message)
+        self.suppressed = suppressed
+        if ex:
+            self.url = str(ex.request.url)
+            self.response = ex.response
+        else:
+            self.url = url or ""
+            request = httpx.Request(method, self.url) if self.url else None
+            self.response = httpx.Response(HTTPStatus.FORBIDDEN, request=request)
+        self.message = f"Forbidden request {self.url}, check user permissions."
+        super().__init__(self.message)

--- a/custom_components/hikvision_next/services.py
+++ b/custom_components/hikvision_next/services.py
@@ -46,7 +46,7 @@ def setup_services(hass: HomeAssistant) -> None:
         path = call.data["path"].strip("/")
         payload = call.data.get("payload")
         try:
-            response = await device.request(method, path, present="xml", data=payload)
+            response = await device.request(method, path, present="xml", data=payload, use_forbidden_cache=False)
         except (HTTPStatusError, ISAPIForbiddenError, ISAPIUnauthorizedError) as ex:
             if isinstance(ex.response.content, bytes):
                 response = ex.response.content.decode("utf-8")

--- a/custom_components/hikvision_next/switch.py
+++ b/custom_components/hikvision_next/switch.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
 from . import HikvisionConfigEntry
-from .const import EVENTS_COORDINATOR, HOLIDAY_MODE, SECONDARY_COORDINATOR
+from .const import EVENTS, EVENTS_COORDINATOR, HOLIDAY_MODE, SECONDARY_COORDINATOR
 from .isapi import EventInfo, ISAPISetEventStateMutexError
 from .isapi.const import EVENT_IO
 
@@ -62,12 +62,18 @@ class EventSwitch(CoordinatorEntity, SwitchEntity):
         self.entity_id = ENTITY_ID_FORMAT.format(event.unique_id)
         self._attr_unique_id = self.entity_id
         self._attr_device_info = coordinator.device.hass_device_info(device_id)
-        self._attr_translation_key = event.id
-        if event.id == EVENT_IO:
-            self._attr_translation_placeholders = {"io_port_id": event.io_port_id}
         self._attr_entity_registry_enabled_default = not event.disabled
         self.device_id = device_id
         self.event = event
+
+        # For multi-channel devices, add channel suffix to name for clarity
+        if coordinator.device.capabilities.is_multi_channel and event.channel_id > 0:
+            base_label = EVENTS[event.id]["label"]
+            self._attr_name = f"{base_label} Detection (Ch. {event.channel_id})"
+        else:
+            self._attr_translation_key = event.id
+            if event.id == EVENT_IO:
+                self._attr_translation_placeholders = {"io_port_id": event.io_port_id}
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/hikvision_next/translations/en.json
+++ b/custom_components/hikvision_next/translations/en.json
@@ -54,6 +54,12 @@
       },
       "io": {
         "name": "Alarm Input {io_port_id}"
+      },
+      "pir": {
+        "name": "PIR"
+      },
+      "thermometry": {
+        "name": "Thermometry"
       }
     },
     "switch": {
@@ -89,6 +95,12 @@
       },
       "io": {
         "name": "Alarm Input {io_port_id}"
+      },
+      "pir": {
+        "name": "PIR Detection"
+      },
+      "thermometry": {
+        "name": "Thermometry Detection"
       }
     },
     "camera": {

--- a/tests/fixtures/devices/DS-2TD1228-2-QA-V5.5.338.json
+++ b/tests/fixtures/devices/DS-2TD1228-2-QA-V5.5.338.json
@@ -1,0 +1,2073 @@
+{
+  "data": {
+    "ISAPI": {
+      "System/deviceInfo": {
+        "response": {
+          "DeviceInfo": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "deviceName": "XXXXX",
+            "manufacturer": null,
+            "deviceID": "xxxxxxxxxxx",
+            "deviceDescription": "IPCamera",
+            "deviceLocation": "hangzhou",
+            "systemContact": "Hikvision.China",
+            "model": "DS-2TD1228-2/QA",
+            "serialNumber": "DS-2TD1228-2/QAXXXXXXXXXXXXXXX",
+            "macAddress": "12:40:43:f8:fa:38",
+            "firmwareVersion": "V5.5.338",
+            "firmwareReleasedDate": "build 250819",
+            "encoderVersion": "V7.3",
+            "encoderReleasedDate": "build 250819",
+            "bootVersion": "V1.3.4",
+            "bootReleasedDate": "100316",
+            "hardwareVersion": "0x0",
+            "deviceType": "IPCamera",
+            "telecontrolID": "88",
+            "supportBeep": "false",
+            "supportVideoLoss": "false",
+            "bootTime": "2025-12-08T12:28:23+01:00",
+            "platformName": "G5",
+            "releaseRegion": "abroad",
+            "opticalFiberNumber": "0",
+            "languageType": "english",
+            "OEMCode": "1",
+            "deviceAssembleType": "endDevice",
+            "deviceCategory": "imagingDevice"
+          }
+        }
+      },
+      "System/capabilities": {
+        "response": {
+          "DeviceCap": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "isSupportDeviceInfo": "true",
+            "isSupportOnlineUpgradeTask": "true",
+            "SysCap": {
+              "isSupportDst": "true",
+              "NetworkCap": {
+                "isSupportWireless": "false",
+                "isSupportPPPoE": "true",
+                "isSupportBond": "false",
+                "isSupport802_1x": "true",
+                "isSupportNtp": "true",
+                "isSupportFtp": "true",
+                "isSupportUpnp": "true",
+                "isSupportDdns": "true",
+                "isSupportHttps": "true",
+                "SnmpCap": {
+                  "isSupport": "true"
+                },
+                "isSupportExtNetCfg": "true",
+                "isSupportIPFilter": "true",
+                "isSupportSSH": "true",
+                "isSupportEZVIZ": "true",
+                "isSupportTrafficMonitor": "false",
+                "isSupportEhome": "true",
+                "isSupportWirelessDial": "false",
+                "isSupportWirelessServer": "false",
+                "isWirelessMutexWithWirelessServer": "false",
+                "isSupportMACFilter": "true",
+                "isSupportIntegrate": "true",
+                "isSupportPlatformAccess": "true",
+                "isSupportWebSocket": "true",
+                "isSupportWebSocketS": "true",
+                "isSupportVideoImgDB": "false",
+                "isSupportEventDataOverWebSocket": {
+                  "@opt": "true,false",
+                  "#text": "false"
+                },
+                "isSupportGRIDServer": "false",
+                "isSupportGRIDInfo": "false",
+                "isSupportEZVIZUnbind": "false",
+                "isSupportModbusAccess": "true",
+                "isSupportModbusTestSubordinateStatus": "true",
+                "isSupportGetModbusAndRegisterMap": "true",
+                "isSupportDSTPProtocolsCap": "true",
+                "isSupportNetworkModuleUpgrade": "false",
+                "isSupportNetworkModuleVersionInfo": "false",
+                "isSupportDynamicHostName": "true",
+                "isSupportSouthernPowerGridServer": "false"
+              },
+              "IOCap": {
+                "IOInputPortNums": "1",
+                "IOOutputPortNums": "1",
+                "isSupportStrobeLamp": "false",
+                "isSupportWebDisplayAlarmStatus": "true"
+              },
+              "SerialCap": {
+                "rs485PortNums": "1",
+                "supportRS232Config": "true",
+                "rs422PortNums": "0",
+                "rs232PortNums": "1",
+                "isSupportAuthenticationService": "false"
+              },
+              "VideoCap": {
+                "videoInputPortNums": "0",
+                "videoOutputPortNums": "0",
+                "isSupportHeatmap": "false",
+                "isSupportCounting": "false",
+                "isSupportMotionDetection": "true",
+                "isSupportTamperDetection": "true",
+                "isSupportPicture": "true",
+                "isSupportPrivacyMask": "true",
+                "OSDLanguage": {
+                  "@opt": "GBK,EUC-KR",
+                  "#text": "GBK"
+                },
+                "isSupportMenuStatus": "false",
+                "pictureChannelList": [
+                  {
+                    "channelID": "1"
+                  },
+                  {
+                    "channelID": "2"
+                  }
+                ]
+              },
+              "AudioCap": {
+                "audioInputNums": "1",
+                "audioOutputNums": "1"
+              },
+              "isSupportCustomAlarmHTTPParams": "true",
+              "isSupportTestCustomAlarmHTTP": "true",
+              "isSupportMetadata": "true",
+              "isSupportSubscribeEvent": "true",
+              "isSupportDiagnosedData": "true",
+              "isSupportGettingWorkingStatus": "true",
+              "isSupportDiagnosedDataParameter": "true",
+              "isSupportTimeCap": "true",
+              "isSupportThermalStreamData": "true"
+            },
+            "voicetalkNums": "1",
+            "isSupportSnapshot": "true",
+            "SecurityCap": {
+              "supportUserNums": "32",
+              "userBondIpNums": "0",
+              "userBondMacNums": "0",
+              "isSupCertificate": "true",
+              "issupIllegalLoginLock": "true",
+              "isSupportOnlineUser": "true",
+              "isSupportAnonymous": "false",
+              "isSupportStreamEncryption": "false",
+              "securityVersion": {
+                "@opt": "1",
+                "#text": "1"
+              },
+              "keyIterateNum": "100",
+              "isSupportUserCheck": "true",
+              "isSupportSecurityQuestionConfig": "false",
+              "SecurityLimits": {
+                "LoginPasswordLenLimit": {
+                  "@min": "1",
+                  "@max": "16"
+                },
+                "SecurityAnswerLenLimit": {
+                  "@min": "1",
+                  "@max": "128"
+                }
+              },
+              "RSAKeyLength": {
+                "@opt": "1024,2048",
+                "@def": "2048",
+                "#text": "4096"
+              },
+              "isSupportONVIFUserManagement": "true",
+              "WebCertificateCap": {
+                "CertificateType": {
+                  "@opt": "digest,digest/basic",
+                  "#text": "digest/basic"
+                },
+                "SecurityAlgorithm": {
+                  "algorithmType": {
+                    "@opt": "MD5,SHA256,MD5/SHA256",
+                    "#text": "MD5"
+                  }
+                }
+              },
+              "isSupportConfigFileImport": "true",
+              "isSupportConfigFileExport": "true",
+              "cfgFileSecretKeyLenLimit": {
+                "@min": "1",
+                "@max": "16",
+                "#text": "16"
+              },
+              "isIrreversible": "true",
+              "salt": "xxxxxxxxxxxxxxxxxxxxxxxxx",
+              "isSupportSIPCertificatesManagement": "false",
+              "isSupportRTSPCertificate": "true",
+              "isSupportGB35114Certificate": "false",
+              "maxIllegalLoginTimes": {
+                "@min": "3",
+                "@max": "20",
+                "@def": "5",
+                "#text": "5"
+              },
+              "maxIllegalLoginLockTime": {
+                "@min": "1",
+                "@max": "120",
+                "@def": "30",
+                "#text": "30"
+              },
+              "SecurityAdvanced": {
+                "noOperationEnabled": "true",
+                "noOperationTime": {
+                  "@min": "1",
+                  "@max": "60",
+                  "@def": "10",
+                  "#text": "10"
+                }
+              },
+              "LoginLinkNum": {
+                "maxLinkNum": {
+                  "@min": "1",
+                  "@max": "128",
+                  "@def": "50",
+                  "#text": "50"
+                }
+              },
+              "isSupportDeviceCertificatesManagement": "true",
+              "isSupportDeviceSelfSignCertExport": "true",
+              "isSupportCCClientCertificate": "true",
+              "isSupportCertificateCustomID": "true",
+              "isSupportEncryptCertificate": "true"
+            },
+            "EventCap": {
+              "isSupportHDFull": "true",
+              "isSupportHDError": "true",
+              "isSupportNicBroken": "true",
+              "isSupportIpConflict": "true",
+              "isSupportIllAccess": "true",
+              "isSupportViException": "false",
+              "isSupportViMismatch": "false",
+              "isSupportRecordException": "false",
+              "isSupportTriggerFocus": "false",
+              "isSupportMotionDetection": "true",
+              "isSupportVideoLoss": "false",
+              "isSupportTamperDetection": "true",
+              "isSupportFireDetection": "false",
+              "isSupportPersonDensityDetection": "false",
+              "isSupportFaceThermometry": "false",
+              "isSupportVoltageInstable": "false",
+              "isSupportCertificateRevocation": [
+                "true",
+                "true"
+              ],
+              "isSupportPTLocking": "false",
+              "isSupportLowCoolerLifeEvent": "false",
+              "isSupportGreyScaleAlarm": "false",
+              "isSupportWasteGasDetection": "false",
+              "RegionScheduleCap": {
+                "isSupportPersonDensityDetection": "false"
+              },
+              "isSupportSmokingDetectAlarm": "false",
+              "isSupportThermalCalibrationFileException": "true",
+              "isSupportTemperatureIntervalMeasurement": "true",
+              "isSupportThermalVehicleDetection": "false",
+              "isSupportObstacleAvoidanceAlarm": "false",
+              "isSupportMixedTargetDetection": "false",
+              "isSupportInsulatorDetection": "false"
+            },
+            "RacmCap": {
+              "nasNums": "8",
+              "pictureSearchType": {
+                "@opt": "CMR,MOTION,ALARM,scenechangedetection,fireDetection,smokeAndFireDetection,smokeDetection,thermometryEarlyWarning,thermometryAlarm,thermometryDiffAlarm,HEOP,temperatureIntervalMeasurement"
+              },
+              "recordSearchType": {
+                "@opt": "CMR,MOTION,ALARM,EDR,ALARMANDMOTION,AllEvent,AudioDetection,scenechangedetection,thermometryEarlyWarning,thermometryAlarm,thermometryDiffAlarm,temperatureIntervalMeasurement"
+              },
+              "SecurityLog": {
+                "isSupportSecurityLog": "true",
+                "isSupportLogServer": "true",
+                "isSupportLogServerTest": "true",
+                "SecurityLogTypeList": {
+                  "SecurityLogType": [
+                    {
+                      "primaryType": "All",
+                      "secondaryType": {
+                        "@opt": "all"
+                      }
+                    },
+                    {
+                      "primaryType": "Operation",
+                      "secondaryType": {
+                        "@opt": "all,alarmSmsSend,callOnline,devicePowerOff,devicePowerOn,deviceRecycle,localAddIpc,localAddNas,localUserManagement,localCfgSecurity,localCfgNetwork,localCfgTime,localCfgPara,localCtrlPtz,localDelIpc,localDelNas,localDial,localDialParaSet,localDialScheduleSet,localDownloadCfgFile,localDownloadCountingFile,localDownloadHeatMapFile,localDownloadPicFile,localDownloadRecFile,localExportBlackWhiteListFile,localExportIpcCfg,localFormatDisk,localHdTest,localImportBlackWhiteListFile,localImportIpcCfg,localIpcUpgrade,localLock,localLockFile,localLogOut,localLogin,localManulAlarm,localPin,localPlayByFile,localPlayByTime,localResetPasswd,localSetIpc,localSetNas,localSetSIPServer,localSetSnmp,localSmsRead,localSmsSearch,localSmsSend,localSpareOperate,localStartPicRec,localStartRec,localStopPicRec,localStopRec,localTagOperation,localUnlock,localUnlockFile,localUpdate,localUploadCfgFile,localWhitelistSet,platOper,remoteAddIpc,remoteAddNas,remoteArm,remotecfgauditpolicy,remoteUserManagement,remoteCfgSecurity,remoteCfgNetwork,remoteCfgTime,remoteCfgPara,remoteCreateCloudStoragePool,remoteCtrlPtz,remoteDelHdisk,remoteDelIpc,remoteDelNas,remoteDeleteCloudStoragePool,remoteDeletePic,remoteDeleteRecord,remoteDialConnect,remoteDialDisconn,remoteDialParaSet,remoteDialScheduleSet,remoteDisArm,remoteDisableCloudStorage,remoteDownloadCfgFile,remoteDownloadRecFile,remoteEnableCloudStorage,remoteExportBlackWhiteListFile,remoteExportIpcCfg,remoteFormatHd,remoteGetParaSecurity,remoteGetParaNetwork,remoteGetPara,remoteGetStatus,remoteImportBlackWhiteListFile,VcaLibRestore,remoteImportIpcCfg,remoteLoadHdisk,remoteLockFile,remoteLogin,remoteLogout,remoteManulAlarm,remoteModCloudStorageParam,remoteModCloudStorageVolume,remotePicBackUp,remotePin,remotePlayByFile,remotePlayByTime,remotePowerOff,remotePowerRecycle,remoteSetIpc,remoteSetNas,remoteSetSIPServer,remoteSetSnmp,remoteSmsRead,remoteSmsSearch,remoteSmsSend,remoteSpareOperate,remoteStartPicRec,remoteStartRec,remoteStartTransChan,remoteStopPicRec,remoteStopRec,remoteStopTransChan,remoteTagOperation,remoteUnloadHdisk,remoteUnlockFile,remoteUpgrade,remoteUploadCfgFile,remoteWhitelistSet,remotelIpcUpgrade,smsControl,smsRecv,startVoiceTalk,stopAbnormal,stopVoiceTalk,localSetDeviceActive,localParamSimpleDefault,localParamFactoryDefault,remoteSetDeviceActive,remoteParamSimpleDefault,remoteParamFactoryDefault,localWPSLink,remoteWPSLink,localResetLoginPassWord,remoteResetLoginPassWord,localfaceBaseCreate,localfaceBaseModify,localfaceBaseDelete,localfaceDataAppend,localfaceDataEdit,localfaceDataDelete,localVcaAnalysisConfig,remotefaceBaseCreate,remotefaceBaseModify,remotefaceBaseDelete,remotefaceDataAppend,remotefaceDataEdit,remotefaceDataDelete,remoteVcaAnalysisConfig,localClusterNetworkConfig,localClusterAddDevice,localClusterDelDevice,remoteClusterNetworkConfig,remoteClusterAddDevice,remoteClusterDelDevice,localSetPoeWorkMode,remoteSetPoeWorkMode,localClusterModeConfig,remoteClusterModeConfig,localIOTCfgFileInput,localIOTCfgFileOutput,localIOTAdd,localIOTDelete,localIOTSet,remoteIOTCfgFileInput,remoteIOTCfgFileOutput,remoteIOTAdd,remoteIOTDelete,remoteIOTSet,localCheckTime,remoteCheckTime,remoteFaceContrastTask,unlockSession,terminateHttp,terminateHttps,terminateSSH,selfTest"
+                      }
+                    },
+                    {
+                      "primaryType": "Event",
+                      "secondaryType": {
+                        "@opt": "all,anrRecordException,dialException,hdError,hdFull,illlegealAccess,ipConflict,ipcDisconnect,ipcIpConfilict,ipcmCrash,netBroken,poePowerException,recordError,recordOverFLow,spareException,startIpcMasException,uploadDataCsException,viAndResMismatch,videoException,videoFormatMismatch,videoLost,syncIPCPasswd,ezvizOffline,SDCardAbnormal,SDCardDamage,plateAbnormal,abnormalPort,POC,vcaCameraAngleAnomaly,dataDiskError,intelligentSystemRunningError,facesnapResolutionOverflow,SMDResolutionOverflow,clusterConfigFailed,clusterStorFullException,clusterOfflineNodeException,clusterRecordCycleException,clusterIPCTransferException,vcaSenceException,ClusterDeviceOffline,clusterDisasterToleranceExcept,clusterVersionException,getSubStreamFailure,locked,hddSHMDetectException,safetyHelmetException,faceModelException,validateCert,establishSecSession,replayAttacks,ntpCheckTime,lowAuditLogStorage,httpConnect,httpsConnect,sshConnect,httpDisconnect,httpsDisconnect,sshDisconnect"
+                      }
+                    },
+                    {
+                      "primaryType": "Other",
+                      "secondaryType": {
+                        "@opt": "all"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "PTZCtrlCap": {
+              "isSupportPatrols": "false",
+              "isSupportCombinedPath": "false"
+            },
+            "SmartCap": {
+              "isSupportROI": "true",
+              "isSupportFaceDetect": "false",
+              "isSupportIntelliTrace": "false",
+              "isSupportFieldDetection": "false",
+              "isSupportDefocusDetection": "false",
+              "isSupportAudioDetection": "true",
+              "isSupportSceneChangeDetection": "true",
+              "isSupportLineDetection": "false",
+              "isSupportRegionEntrance": "false",
+              "isSupportRegionExiting": "false",
+              "isSupportLoitering": "false",
+              "isSupportGroup": "false",
+              "isSupportRapidMove": "false",
+              "isSupportParking": "false",
+              "isSupportUnattendedBaggage": "false",
+              "isSupportAttendedBaggage": "false",
+              "isSupportShipsDetection": "false",
+              "isSupportNobodyDetection": "false",
+              "isSupportNobodyShieldMask": "false"
+            },
+            "TestCap": {
+              "@version": "2.0",
+              "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+              "isSupportFTPTest": "true",
+              "isSupportPingTest": "true",
+              "isSupportNTPTest": "true",
+              "isSupportNASTest": "true",
+              "isSupportEmailTest": "true"
+            },
+            "isSupportRealtimeTempHumi": "true",
+            "isSupportGIS": "false",
+            "isSupportCompass": "false",
+            "isSupportStreamDualVCA": "true",
+            "DualVCA": {
+              "isSupportdualVCAList": "true",
+              "enabled": {
+                "@opt": "ture,false",
+                "@def": "true",
+                "#text": "true"
+              },
+              "overlapRangeType": {
+                "@opt": "ruleRegion,fullScreen",
+                "@def": "ruleRegion",
+                "#text": "fullScreen"
+              }
+            },
+            "ImageMiscCap": {
+              "@version": "2.0",
+              "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+              "isSupportDPC": "true"
+            },
+            "isSupportRtspOverHTTPS": "true",
+            "ThermalCap": {
+              "isSupportThermometry": "true",
+              "isSupportRealtimeThermometry": "true",
+              "isSupportThermIntell": "true",
+              "isSupportThermometrySchedule": "true",
+              "isSupportPower": "false",
+              "isSupportRealtimeTempHumi": "true",
+              "isSupportThermometryMode": "true",
+              "isSupportThermalPip": "true",
+              "isSupportThermalIntelRuleDisplay": "true",
+              "AlgVersionInfo": {
+                "thermometryAlgName": {
+                  "@min": "1",
+                  "@max": "128"
+                }
+              },
+              "isSupportThermalStreamParam": "true",
+              "isSupportClickToThermometry": "true",
+              "isSupportThermometryHistorySearch": "false",
+              "isSupportThermometryShieldMask": "true",
+              "isSupportTemperatureCorrection": "false",
+              "isSupportBurningPrevention": "false",
+              "isSupportJpegPicWithAppendData": "true",
+              "isSupportRealTimethermometryForHTTP": "true",
+              "isSupportTemperatureIntervalMeasurement": "true",
+              "isSupportThermalDataLinkInfo": "true",
+              "isSupportWebDisplayPixelToPixelParam": "true",
+              "isSupportExportThermalCalibrationFile": "true"
+            },
+            "isSupportCurrentLock": "false",
+            "isSupportPlayback": "true",
+            "isSupportChannelEventCap": "true",
+            "isSupportChannelEventListCap": "true",
+            "OpenPlatformCap": {
+              "isSupportOpenPlatform": "false"
+            },
+            "IOTCap": {
+              "@version": "2.0",
+              "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+              "supportChannelNum": {
+                "@opt": "2",
+                "#text": "2"
+              },
+              "startChannelNo": "1",
+              "isSupportlinkageChannelsSearch": "false"
+            },
+            "isSupportImageCap": "true",
+            "isSupportCalibrationFile": "true",
+            "isSupportDisplayTrajectory": "true",
+            "Maximumsuperpositiontime": {
+              "@opt": "5,10,20,30",
+              "#text": "10"
+            },
+            "isSupportUnitConfig": "true",
+            "isSupportActiveMulticast": "true",
+            "isSupportDiscoveryMode": "true",
+            "isSupportPictureServer": "true",
+            "isSupportDevStatus": "true",
+            "isSupportSnapshotAsync": "true",
+            "isSupportRemoveStorage": "false",
+            "isSupportPTModulePowerCfg": "false",
+            "isSupportDelayedReboot": "false",
+            "isSupportHardwareReboot": "false",
+            "isSupportAutoMaintenance": "true",
+            "isSupportDiagnosisDataCollectionParams": "true",
+            "isSupportISUPHttpPassthrough": "true",
+            "isSupportKeyFunctionList": "false",
+            "isSupportKeyValueList": "false",
+            "isSupportMenuFunctionList": "false",
+            "isSupportImageVignettingOptimizeParams": "false",
+            "isSupportDisplayThermometryFirePrevention": "false",
+            "isSupportChildmanage": "true",
+            "isSupportGetClientAccessCapabilities": "true",
+            "isSupportSupplementAndwhiteAlarmConflictTips": "false",
+            "isSupportFullScreenPosOverlayCap": "true"
+          }
+        }
+      },
+      "System/IO/inputs/1/status": {
+        "response": {
+          "IOPortStatus": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "ioPortID": "1",
+            "ioPortType": "input",
+            "ioState": "inactive"
+          }
+        }
+      },
+      "System/IO/outputs/1/status": {
+        "response": {
+          "IOPortStatus": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "ioPortID": "1",
+            "ioPortType": "output",
+            "ioState": "inactive"
+          }
+        }
+      },
+      "System/Holidays": {
+        "status_code": 403
+      },
+      "System/Video/inputs/channels": {
+        "response": {
+          "VideoInputChannelList": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "VideoInputChannel": [
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "1",
+                "inputPort": "1",
+                "name": "Camera 01",
+                "videoFormat": "PAL"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "2",
+                "inputPort": "2",
+                "name": "Camera 02",
+                "videoFormat": "PAL"
+              }
+            ]
+          }
+        }
+      },
+      "ContentMgmt/InputProxy/channels": {
+        "status_code": 403
+      },
+      "ContentMgmt/Storage": {
+        "response": {
+          "storage": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "hddList": {
+              "@version": "1.0",
+              "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+              "@size": "8",
+              "hdd": {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "1",
+                "hddName": "hdde",
+                "hddPath": null,
+                "hddType": "SATA",
+                "status": "ok",
+                "capacity": "244480",
+                "freeSpace": "92672",
+                "property": "RW",
+                "formatType": {
+                  "@opt": "EXT4",
+                  "#text": "EXT4"
+                },
+                "Encryption": {
+                  "passwordLen": {
+                    "@min": "6",
+                    "@max": "63"
+                  },
+                  "encryptionStatus": {
+                    "@opt": "unencrypted,encrypted,verfyFailed",
+                    "#text": "encrypted"
+                  },
+                  "encryptFormatType": {
+                    "@opt": "FAT32,EXT4",
+                    "#text": "EXT4"
+                  }
+                }
+              }
+            },
+            "nasList": {
+              "@version": "2.0",
+              "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+              "supportMountType": {
+                "@opt": "NFS,SMB/CIFS"
+              },
+              "authentication": {
+                "@opt": "SMB/CIFS"
+              }
+            },
+            "workMode": "quota",
+            "posInfoStoragingEnabled": "true"
+          }
+        }
+      },
+      "Security/adminAccesses": {
+        "response": {
+          "AdminAccessProtocolList": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "AdminAccessProtocol": [
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "1",
+                "enabled": "true",
+                "protocol": "HTTP",
+                "portNo": "80"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "2",
+                "enabled": "true",
+                "protocol": "HTTPS",
+                "redirectToHttps": "true",
+                "portNo": "443",
+                "TLS1_1Enable": "false",
+                "TLS1_2Enable": "true"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "3",
+                "enabled": "true",
+                "protocol": "DEV_MANAGE",
+                "portNo": "8000"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "4",
+                "enabled": "true",
+                "protocol": "RTSP",
+                "portNo": "554"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "5",
+                "enabled": "true",
+                "protocol": "WebSocket",
+                "portNo": "7681"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "6",
+                "enabled": "true",
+                "protocol": "WebSocketS",
+                "portNo": "7682"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "8",
+                "enabled": "true",
+                "protocol": "SRTP",
+                "portNo": "322"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "9",
+                "enabled": "true",
+                "protocol": "modbusTCP",
+                "portNo": "502"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "10",
+                "enabled": "true",
+                "protocol": "Bonjour"
+              }
+            ]
+          }
+        }
+      },
+      "Event/triggers": {
+        "response": {
+          "EventNotification": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "EventTriggerList": {
+              "@version": "2.0",
+              "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+              "EventTrigger": [
+                {
+                  "id": [
+                    "IO-1",
+                    "io-1"
+                  ],
+                  "eventType": [
+                    "IO",
+                    "io-1"
+                  ],
+                  "eventDescription": [
+                    "IO Event trigger Information",
+                    "exception Information"
+                  ],
+                  "inputIOPortID": "1",
+                  "EventTriggerNotificationList": null
+                },
+                {
+                  "id": [
+                    "VMD-1",
+                    "vmd-1"
+                  ],
+                  "eventType": [
+                    "VMD",
+                    "vmd-1"
+                  ],
+                  "eventDescription": [
+                    "VMD Event trigger Information",
+                    "exception Information"
+                  ],
+                  "EventTriggerNotificationList": {
+                    "EventTriggerNotification": [
+                      {
+                        "id": "record-1",
+                        "notificationMethod": "record",
+                        "notificationRecurrence": "beginning",
+                        "videoInputID": "1"
+                      },
+                      {
+                        "id": "beep",
+                        "notificationMethod": "beep",
+                        "notificationRecurrence": "beginning"
+                      },
+                      {
+                        "id": "center",
+                        "notificationMethod": "center",
+                        "notificationRecurrence": "beginning"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": [
+                    "tamper-1",
+                    "tamper-1"
+                  ],
+                  "eventType": [
+                    "tamperdetection",
+                    "tamper-1"
+                  ],
+                  "eventDescription": [
+                    "shelteralarm Event trigger Information",
+                    "exception Information"
+                  ],
+                  "EventTriggerNotificationList": null
+                },
+                {
+                  "id": "diskfull",
+                  "eventType": "diskfull",
+                  "eventDescription": "exception Information",
+                  "EventTriggerNotificationList": null
+                },
+                {
+                  "id": "diskerror",
+                  "eventType": "diskerror",
+                  "eventDescription": "exception Information",
+                  "EventTriggerNotificationList": {
+                    "EventTriggerNotification": {
+                      "id": "beep",
+                      "notificationMethod": "beep",
+                      "notificationRecurrence": "beginning"
+                    }
+                  }
+                },
+                {
+                  "id": "nicbroken",
+                  "eventType": "nicbroken",
+                  "eventDescription": "exception Information",
+                  "EventTriggerNotificationList": null
+                },
+                {
+                  "id": "ipconflict",
+                  "eventType": "ipconflict",
+                  "eventDescription": "exception Information",
+                  "EventTriggerNotificationList": null
+                },
+                {
+                  "id": "illaccess",
+                  "eventType": "illaccess",
+                  "eventDescription": "exception Information",
+                  "EventTriggerNotificationList": null
+                },
+                {
+                  "id": "badvideo",
+                  "eventType": "badvideo",
+                  "eventDescription": "exception Information",
+                  "EventTriggerNotificationList": null
+                },
+                {
+                  "id": [
+                    "audioexception-1",
+                    "audioexception-1"
+                  ],
+                  "eventType": [
+                    "audioexception",
+                    "audioexception-1"
+                  ],
+                  "eventDescription": [
+                    "audioexception Event trigger Information",
+                    "exception Information"
+                  ],
+                  "EventTriggerNotificationList": null
+                },
+                {
+                  "id": [
+                    "thermometry-2",
+                    "thermometry-2"
+                  ],
+                  "eventType": [
+                    "thermometry",
+                    "thermometry-2"
+                  ],
+                  "eventDescription": [
+                    "thermometry Event trigger Information",
+                    "exception Information"
+                  ],
+                  "videoInputChannelID": "2",
+                  "dynVideoInputChannelID": "2",
+                  "EventTriggerNotificationList": {
+                    "EventTriggerNotification": {
+                      "id": "center",
+                      "notificationMethod": "center",
+                      "notificationRecurrence": "beginning"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Event/channels/capabilities": {
+        "response": {
+          "ChannelEventCapList": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "ChannelEventCap": [
+              {
+                "eventType": {
+                  "@opt": "VMD,motionDetection,shelteralarm,tamperDetection,ROI,audioexception,audioDetection,scenechangedetection,sceneChangeDetection,temperature,temperatureDetection,IO,diskfull,diskerror,nicbroken,ipconflict,illaccess,thermometry"
+                },
+                "shieldEventType": {
+                  "@opt": "behavior, faceSnap, humanRecognition"
+                },
+                "channelID": "1",
+                "id": "1"
+              },
+              {
+                "eventType": {
+                  "@opt": "VMD,motionDetection,shelteralarm,tamperDetection,ROI,fielddetection,fieldDetection,scenechangedetection,sceneChangeDetection,linedetection,lineDetection,regionEntrance,regionExiting,temperature,temperatureDetection,IO,diskfull,diskerror,nicbroken,ipconflict,illaccess,thermometry,temperatureIntervalMeasurement"
+                },
+                "shieldEventType": {
+                  "@opt": "behavior, faceSnap, humanRecognition"
+                },
+                "channelID": "2",
+                "id": "2"
+              }
+            ]
+          }
+        }
+      },
+      "Event/triggers/scenechangedetection-1": {
+        "response": {
+          "EventTrigger": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": [
+              "scenechangedetection-1",
+              "scenechangedetection-1"
+            ],
+            "eventType": [
+              "scenechangedetection",
+              "scenechangedetection-1"
+            ],
+            "eventDescription": [
+              "scenechangedetection Event trigger Information",
+              "exception Information"
+            ],
+            "EventTriggerNotificationList": null
+          }
+        }
+      },
+      "Event/notification/httpHosts": {
+        "response": {
+          "HttpHostNotificationList": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "HttpHostNotification": [
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "1",
+                "url": "/api/hikvision",
+                "protocolType": "HTTP",
+                "parameterFormatType": "XML",
+                "addressingFormatType": "ipaddress",
+                "ipAddress": "1.0.0.101",
+                "portNo": "8123",
+                "userName": null,
+                "httpAuthenticationMethod": "none"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "2",
+                "url": "/",
+                "protocolType": "HTTP",
+                "parameterFormatType": "XML",
+                "addressingFormatType": "ipaddress",
+                "ipAddress": "0.0.0.0",
+                "portNo": "80",
+                "userName": null,
+                "httpAuthenticationMethod": "none"
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "3",
+                "url": "/",
+                "protocolType": "HTTP",
+                "parameterFormatType": "XML",
+                "addressingFormatType": "ipaddress",
+                "ipAddress": "0.0.0.0",
+                "portNo": "80",
+                "userName": null,
+                "httpAuthenticationMethod": "none"
+              }
+            ]
+          }
+        }
+      },
+      "Streaming/channels": {
+        "response": {
+          "StreamingChannelList": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "StreamingChannel": [
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "101",
+                "channelName": "Camera 01",
+                "enabled": "true",
+                "Transport": {
+                  "maxPacketSize": "1000",
+                  "ControlProtocolList": {
+                    "ControlProtocol": [
+                      {
+                        "streamingTransport": "RTSP"
+                      },
+                      {
+                        "streamingTransport": "HTTP"
+                      },
+                      {
+                        "streamingTransport": "SHTTP"
+                      }
+                    ]
+                  },
+                  "Unicast": {
+                    "enabled": "true",
+                    "rtpTransportType": "RTP/TCP"
+                  },
+                  "Multicast": {
+                    "enabled": "true",
+                    "destIPAddress": "239.0.0.1",
+                    "videoDestPortNo": "8860",
+                    "audioDestPortNo": "8862"
+                  },
+                  "Security": {
+                    "enabled": "true",
+                    "certificateType": "digest",
+                    "SecurityAlgorithm": {
+                      "algorithmType": "MD5"
+                    }
+                  },
+                  "SRTPMulticast": {
+                    "SRTPVideoDestPortNo": "18860",
+                    "SRTPAudioDestPortNo": "18862"
+                  }
+                },
+                "Video": {
+                  "enabled": "true",
+                  "videoInputChannelID": "1",
+                  "videoCodecType": "H.265",
+                  "videoScanType": "progressive",
+                  "videoResolutionWidth": "1920",
+                  "videoResolutionHeight": "1080",
+                  "videoQualityControlType": "VBR",
+                  "constantBitRate": "3072",
+                  "fixedQuality": "60",
+                  "vbrUpperCap": "3072",
+                  "vbrLowerCap": "32",
+                  "maxFrameRate": "2500",
+                  "keyFrameInterval": "2000",
+                  "snapShotImageType": "JPEG",
+                  "GovLength": "50",
+                  "SVC": {
+                    "enabled": "false"
+                  },
+                  "PacketType": [
+                    "PS",
+                    "RTP"
+                  ],
+                  "smoothing": "50",
+                  "IntelligentInfoDisplayMethod": "non-player"
+                },
+                "Audio": {
+                  "enabled": "true",
+                  "audioInputChannelID": "1",
+                  "audioCompressionType": "G.711ulaw"
+                }
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "102",
+                "channelName": "Camera 01",
+                "enabled": "true",
+                "Transport": {
+                  "maxPacketSize": "1000",
+                  "ControlProtocolList": {
+                    "ControlProtocol": [
+                      {
+                        "streamingTransport": "RTSP"
+                      },
+                      {
+                        "streamingTransport": "HTTP"
+                      },
+                      {
+                        "streamingTransport": "SHTTP"
+                      }
+                    ]
+                  },
+                  "Unicast": {
+                    "enabled": "true",
+                    "rtpTransportType": "RTP/TCP"
+                  },
+                  "Multicast": {
+                    "enabled": "true",
+                    "destIPAddress": "239.0.0.1",
+                    "videoDestPortNo": "8866",
+                    "audioDestPortNo": "8868"
+                  },
+                  "Security": {
+                    "enabled": "true",
+                    "certificateType": "digest",
+                    "SecurityAlgorithm": {
+                      "algorithmType": "MD5"
+                    }
+                  },
+                  "SRTPMulticast": {
+                    "SRTPVideoDestPortNo": "18866",
+                    "SRTPAudioDestPortNo": "18868"
+                  }
+                },
+                "Video": {
+                  "enabled": "true",
+                  "videoInputChannelID": "1",
+                  "videoCodecType": "H.264",
+                  "videoScanType": "progressive",
+                  "videoResolutionWidth": "704",
+                  "videoResolutionHeight": "576",
+                  "videoQualityControlType": "VBR",
+                  "constantBitRate": "1024",
+                  "fixedQuality": "60",
+                  "vbrUpperCap": "1024",
+                  "vbrLowerCap": "32",
+                  "maxFrameRate": "2500",
+                  "keyFrameInterval": "2000",
+                  "snapShotImageType": "JPEG",
+                  "H264Profile": "Main",
+                  "GovLength": "50",
+                  "SVC": {
+                    "enabled": "false"
+                  },
+                  "PacketType": [
+                    "PS",
+                    "RTP"
+                  ],
+                  "smoothing": "50",
+                  "IntelligentInfoDisplayMethod": "non-player"
+                },
+                "Audio": {
+                  "enabled": "true",
+                  "audioInputChannelID": "1",
+                  "audioCompressionType": "G.711ulaw"
+                }
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "201",
+                "channelName": "Camera 02",
+                "enabled": "true",
+                "Transport": {
+                  "maxPacketSize": "1000",
+                  "ControlProtocolList": {
+                    "ControlProtocol": [
+                      {
+                        "streamingTransport": "RTSP"
+                      },
+                      {
+                        "streamingTransport": "HTTP"
+                      },
+                      {
+                        "streamingTransport": "SHTTP"
+                      }
+                    ]
+                  },
+                  "Unicast": {
+                    "enabled": "true",
+                    "rtpTransportType": "RTP/TCP"
+                  },
+                  "Multicast": {
+                    "enabled": "true",
+                    "destIPAddress": "239.0.0.1",
+                    "videoDestPortNo": "8878",
+                    "audioDestPortNo": "8880"
+                  },
+                  "Security": {
+                    "enabled": "true",
+                    "certificateType": "digest",
+                    "SecurityAlgorithm": {
+                      "algorithmType": "MD5"
+                    }
+                  },
+                  "SRTPMulticast": {
+                    "SRTPVideoDestPortNo": "18878",
+                    "SRTPAudioDestPortNo": "18880"
+                  }
+                },
+                "Video": {
+                  "enabled": "true",
+                  "videoInputChannelID": "2",
+                  "videoCodecType": "H.264",
+                  "videoScanType": "progressive",
+                  "videoResolutionWidth": "640",
+                  "videoResolutionHeight": "512",
+                  "videoQualityControlType": "CBR",
+                  "constantBitRate": "2048",
+                  "fixedQuality": "60",
+                  "maxFrameRate": "2500",
+                  "keyFrameInterval": "2000",
+                  "snapShotImageType": "JPEG",
+                  "H264Profile": "High",
+                  "GovLength": "50",
+                  "SVC": {
+                    "enabled": "false"
+                  },
+                  "PacketType": [
+                    "PS",
+                    "RTP"
+                  ],
+                  "smoothing": "50",
+                  "IntelligentInfoDisplayMethod": "non-player"
+                },
+                "Audio": {
+                  "enabled": "false",
+                  "audioInputChannelID": "1",
+                  "audioCompressionType": "G.711ulaw"
+                }
+              },
+              {
+                "@version": "2.0",
+                "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+                "id": "202",
+                "channelName": "Camera 02",
+                "enabled": "true",
+                "Transport": {
+                  "maxPacketSize": "1000",
+                  "ControlProtocolList": {
+                    "ControlProtocol": [
+                      {
+                        "streamingTransport": "RTSP"
+                      },
+                      {
+                        "streamingTransport": "HTTP"
+                      },
+                      {
+                        "streamingTransport": "SHTTP"
+                      }
+                    ]
+                  },
+                  "Unicast": {
+                    "enabled": "true",
+                    "rtpTransportType": "RTP/TCP"
+                  },
+                  "Multicast": {
+                    "enabled": "true",
+                    "destIPAddress": "239.0.0.1",
+                    "videoDestPortNo": "8884",
+                    "audioDestPortNo": "8886"
+                  },
+                  "Security": {
+                    "enabled": "true",
+                    "certificateType": "digest",
+                    "SecurityAlgorithm": {
+                      "algorithmType": "MD5"
+                    }
+                  },
+                  "SRTPMulticast": {
+                    "SRTPVideoDestPortNo": "18884",
+                    "SRTPAudioDestPortNo": "18886"
+                  }
+                },
+                "Video": {
+                  "enabled": "true",
+                  "videoInputChannelID": "2",
+                  "videoCodecType": "H.264",
+                  "videoScanType": "progressive",
+                  "videoResolutionWidth": "320",
+                  "videoResolutionHeight": "240",
+                  "videoQualityControlType": "CBR",
+                  "constantBitRate": "1024",
+                  "fixedQuality": "60",
+                  "maxFrameRate": "2500",
+                  "keyFrameInterval": "2000",
+                  "snapShotImageType": "JPEG",
+                  "H264Profile": "Main",
+                  "GovLength": "50",
+                  "SVC": {
+                    "enabled": "false"
+                  },
+                  "PacketType": [
+                    "PS",
+                    "RTP"
+                  ],
+                  "smoothing": "50",
+                  "IntelligentInfoDisplayMethod": "non-player"
+                },
+                "Audio": {
+                  "enabled": "false",
+                  "audioInputChannelID": "1",
+                  "audioCompressionType": "G.711ulaw"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "Streaming/channels/101": {
+        "response": {
+          "StreamingChannel": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "101",
+            "channelName": "Camera 01",
+            "enabled": "true",
+            "Transport": {
+              "maxPacketSize": "1000",
+              "ControlProtocolList": {
+                "ControlProtocol": [
+                  {
+                    "streamingTransport": "RTSP"
+                  },
+                  {
+                    "streamingTransport": "HTTP"
+                  },
+                  {
+                    "streamingTransport": "SHTTP"
+                  }
+                ]
+              },
+              "Unicast": {
+                "enabled": "true",
+                "rtpTransportType": "RTP/TCP"
+              },
+              "Multicast": {
+                "enabled": "true",
+                "destIPAddress": "239.0.0.1",
+                "videoDestPortNo": "8860",
+                "audioDestPortNo": "8862"
+              },
+              "Security": {
+                "enabled": "true",
+                "certificateType": "digest",
+                "SecurityAlgorithm": {
+                  "algorithmType": "MD5"
+                }
+              },
+              "SRTPMulticast": {
+                "SRTPVideoDestPortNo": "18860",
+                "SRTPAudioDestPortNo": "18862"
+              }
+            },
+            "Video": {
+              "enabled": "true",
+              "videoInputChannelID": "1",
+              "videoCodecType": "H.265",
+              "videoScanType": "progressive",
+              "videoResolutionWidth": "1920",
+              "videoResolutionHeight": "1080",
+              "videoQualityControlType": "VBR",
+              "constantBitRate": "3072",
+              "fixedQuality": "60",
+              "vbrUpperCap": "3072",
+              "vbrLowerCap": "32",
+              "maxFrameRate": "2500",
+              "keyFrameInterval": "2000",
+              "snapShotImageType": "JPEG",
+              "GovLength": "50",
+              "SVC": {
+                "enabled": "false"
+              },
+              "PacketType": [
+                "PS",
+                "RTP"
+              ],
+              "smoothing": "50",
+              "IntelligentInfoDisplayMethod": "non-player"
+            },
+            "Audio": {
+              "enabled": "true",
+              "audioInputChannelID": "1",
+              "audioCompressionType": "G.711ulaw"
+            }
+          }
+        }
+      },
+      "Streaming/channels/102": {
+        "response": {
+          "StreamingChannel": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "102",
+            "channelName": "Camera 01",
+            "enabled": "true",
+            "Transport": {
+              "maxPacketSize": "1000",
+              "ControlProtocolList": {
+                "ControlProtocol": [
+                  {
+                    "streamingTransport": "RTSP"
+                  },
+                  {
+                    "streamingTransport": "HTTP"
+                  },
+                  {
+                    "streamingTransport": "SHTTP"
+                  }
+                ]
+              },
+              "Unicast": {
+                "enabled": "true",
+                "rtpTransportType": "RTP/TCP"
+              },
+              "Multicast": {
+                "enabled": "true",
+                "destIPAddress": "239.0.0.1",
+                "videoDestPortNo": "8866",
+                "audioDestPortNo": "8868"
+              },
+              "Security": {
+                "enabled": "true",
+                "certificateType": "digest",
+                "SecurityAlgorithm": {
+                  "algorithmType": "MD5"
+                }
+              },
+              "SRTPMulticast": {
+                "SRTPVideoDestPortNo": "18866",
+                "SRTPAudioDestPortNo": "18868"
+              }
+            },
+            "Video": {
+              "enabled": "true",
+              "videoInputChannelID": "1",
+              "videoCodecType": "H.264",
+              "videoScanType": "progressive",
+              "videoResolutionWidth": "704",
+              "videoResolutionHeight": "576",
+              "videoQualityControlType": "VBR",
+              "constantBitRate": "1024",
+              "fixedQuality": "60",
+              "vbrUpperCap": "1024",
+              "vbrLowerCap": "32",
+              "maxFrameRate": "2500",
+              "keyFrameInterval": "2000",
+              "snapShotImageType": "JPEG",
+              "H264Profile": "Main",
+              "GovLength": "50",
+              "SVC": {
+                "enabled": "false"
+              },
+              "PacketType": [
+                "PS",
+                "RTP"
+              ],
+              "smoothing": "50",
+              "IntelligentInfoDisplayMethod": "non-player"
+            },
+            "Audio": {
+              "enabled": "true",
+              "audioInputChannelID": "1",
+              "audioCompressionType": "G.711ulaw"
+            }
+          }
+        }
+      },
+      "Streaming/channels/103": {
+        "response": {
+          "StreamingChannel": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "103",
+            "channelName": "Camera 01",
+            "enabled": "true",
+            "Transport": {
+              "maxPacketSize": "1000",
+              "ControlProtocolList": {
+                "ControlProtocol": [
+                  {
+                    "streamingTransport": "RTSP"
+                  },
+                  {
+                    "streamingTransport": "HTTP"
+                  },
+                  {
+                    "streamingTransport": "SHTTP"
+                  }
+                ]
+              },
+              "Unicast": {
+                "enabled": "true",
+                "rtpTransportType": "RTP/TCP"
+              },
+              "Multicast": {
+                "enabled": "true",
+                "destIPAddress": "239.0.0.1",
+                "videoDestPortNo": "8860",
+                "audioDestPortNo": "8862"
+              },
+              "Security": {
+                "enabled": "true",
+                "certificateType": "digest",
+                "SecurityAlgorithm": {
+                  "algorithmType": "MD5"
+                }
+              },
+              "SRTPMulticast": {
+                "SRTPVideoDestPortNo": "18860",
+                "SRTPAudioDestPortNo": "18862"
+              }
+            },
+            "Video": {
+              "enabled": "true",
+              "videoInputChannelID": "1",
+              "videoCodecType": "H.265",
+              "videoScanType": "progressive",
+              "videoResolutionWidth": "1920",
+              "videoResolutionHeight": "1080",
+              "videoQualityControlType": "VBR",
+              "constantBitRate": "3072",
+              "fixedQuality": "60",
+              "vbrUpperCap": "3072",
+              "vbrLowerCap": "32",
+              "maxFrameRate": "2500",
+              "keyFrameInterval": "2000",
+              "snapShotImageType": "JPEG",
+              "GovLength": "50",
+              "SVC": {
+                "enabled": "false"
+              },
+              "PacketType": [
+                "PS",
+                "RTP"
+              ],
+              "smoothing": "50",
+              "IntelligentInfoDisplayMethod": "non-player"
+            },
+            "Audio": {
+              "enabled": "true",
+              "audioInputChannelID": "1",
+              "audioCompressionType": "G.711ulaw"
+            }
+          }
+        }
+      },
+      "Streaming/channels/104": {
+        "response": {
+          "StreamingChannel": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "104",
+            "channelName": "Camera 01",
+            "enabled": "true",
+            "Transport": {
+              "maxPacketSize": "1000",
+              "ControlProtocolList": {
+                "ControlProtocol": [
+                  {
+                    "streamingTransport": "RTSP"
+                  },
+                  {
+                    "streamingTransport": "HTTP"
+                  },
+                  {
+                    "streamingTransport": "SHTTP"
+                  }
+                ]
+              },
+              "Unicast": {
+                "enabled": "true",
+                "rtpTransportType": "RTP/TCP"
+              },
+              "Multicast": {
+                "enabled": "true",
+                "destIPAddress": "239.0.0.1",
+                "videoDestPortNo": "8860",
+                "audioDestPortNo": "8862"
+              },
+              "Security": {
+                "enabled": "true",
+                "certificateType": "digest",
+                "SecurityAlgorithm": {
+                  "algorithmType": "MD5"
+                }
+              },
+              "SRTPMulticast": {
+                "SRTPVideoDestPortNo": "18860",
+                "SRTPAudioDestPortNo": "18862"
+              }
+            },
+            "Video": {
+              "enabled": "true",
+              "videoInputChannelID": "1",
+              "videoCodecType": "H.265",
+              "videoScanType": "progressive",
+              "videoResolutionWidth": "1920",
+              "videoResolutionHeight": "1080",
+              "videoQualityControlType": "VBR",
+              "constantBitRate": "3072",
+              "fixedQuality": "60",
+              "vbrUpperCap": "3072",
+              "vbrLowerCap": "32",
+              "maxFrameRate": "2500",
+              "keyFrameInterval": "2000",
+              "snapShotImageType": "JPEG",
+              "GovLength": "50",
+              "SVC": {
+                "enabled": "false"
+              },
+              "PacketType": [
+                "PS",
+                "RTP"
+              ],
+              "smoothing": "50",
+              "IntelligentInfoDisplayMethod": "non-player"
+            },
+            "Audio": {
+              "enabled": "true",
+              "audioInputChannelID": "1",
+              "audioCompressionType": "G.711ulaw"
+            }
+          }
+        }
+      },
+      "Streaming/channels/201": {
+        "response": {
+          "StreamingChannel": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "201",
+            "channelName": "Camera 02",
+            "enabled": "true",
+            "Transport": {
+              "maxPacketSize": "1000",
+              "ControlProtocolList": {
+                "ControlProtocol": [
+                  {
+                    "streamingTransport": "RTSP"
+                  },
+                  {
+                    "streamingTransport": "HTTP"
+                  },
+                  {
+                    "streamingTransport": "SHTTP"
+                  }
+                ]
+              },
+              "Unicast": {
+                "enabled": "true",
+                "rtpTransportType": "RTP/TCP"
+              },
+              "Multicast": {
+                "enabled": "true",
+                "destIPAddress": "239.0.0.1",
+                "videoDestPortNo": "8878",
+                "audioDestPortNo": "8880"
+              },
+              "Security": {
+                "enabled": "true",
+                "certificateType": "digest",
+                "SecurityAlgorithm": {
+                  "algorithmType": "MD5"
+                }
+              },
+              "SRTPMulticast": {
+                "SRTPVideoDestPortNo": "18878",
+                "SRTPAudioDestPortNo": "18880"
+              }
+            },
+            "Video": {
+              "enabled": "true",
+              "videoInputChannelID": "2",
+              "videoCodecType": "H.264",
+              "videoScanType": "progressive",
+              "videoResolutionWidth": "640",
+              "videoResolutionHeight": "512",
+              "videoQualityControlType": "CBR",
+              "constantBitRate": "2048",
+              "fixedQuality": "60",
+              "maxFrameRate": "2500",
+              "keyFrameInterval": "2000",
+              "snapShotImageType": "JPEG",
+              "H264Profile": "High",
+              "GovLength": "50",
+              "SVC": {
+                "enabled": "false"
+              },
+              "PacketType": [
+                "PS",
+                "RTP"
+              ],
+              "smoothing": "50",
+              "IntelligentInfoDisplayMethod": "non-player"
+            },
+            "Audio": {
+              "enabled": "false",
+              "audioInputChannelID": "1",
+              "audioCompressionType": "G.711ulaw"
+            }
+          }
+        }
+      },
+      "Streaming/channels/202": {
+        "response": {
+          "StreamingChannel": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "202",
+            "channelName": "Camera 02",
+            "enabled": "true",
+            "Transport": {
+              "maxPacketSize": "1000",
+              "ControlProtocolList": {
+                "ControlProtocol": [
+                  {
+                    "streamingTransport": "RTSP"
+                  },
+                  {
+                    "streamingTransport": "HTTP"
+                  },
+                  {
+                    "streamingTransport": "SHTTP"
+                  }
+                ]
+              },
+              "Unicast": {
+                "enabled": "true",
+                "rtpTransportType": "RTP/TCP"
+              },
+              "Multicast": {
+                "enabled": "true",
+                "destIPAddress": "239.0.0.1",
+                "videoDestPortNo": "8884",
+                "audioDestPortNo": "8886"
+              },
+              "Security": {
+                "enabled": "true",
+                "certificateType": "digest",
+                "SecurityAlgorithm": {
+                  "algorithmType": "MD5"
+                }
+              },
+              "SRTPMulticast": {
+                "SRTPVideoDestPortNo": "18884",
+                "SRTPAudioDestPortNo": "18886"
+              }
+            },
+            "Video": {
+              "enabled": "true",
+              "videoInputChannelID": "2",
+              "videoCodecType": "H.264",
+              "videoScanType": "progressive",
+              "videoResolutionWidth": "320",
+              "videoResolutionHeight": "240",
+              "videoQualityControlType": "CBR",
+              "constantBitRate": "1024",
+              "fixedQuality": "60",
+              "maxFrameRate": "2500",
+              "keyFrameInterval": "2000",
+              "snapShotImageType": "JPEG",
+              "H264Profile": "Main",
+              "GovLength": "50",
+              "SVC": {
+                "enabled": "false"
+              },
+              "PacketType": [
+                "PS",
+                "RTP"
+              ],
+              "smoothing": "50",
+              "IntelligentInfoDisplayMethod": "non-player"
+            },
+            "Audio": {
+              "enabled": "false",
+              "audioInputChannelID": "1",
+              "audioCompressionType": "G.711ulaw"
+            }
+          }
+        }
+      },
+      "Streaming/channels/203": {
+        "response": {
+          "StreamingChannel": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "203",
+            "channelName": "Camera 02",
+            "enabled": "true",
+            "Transport": {
+              "maxPacketSize": "1000",
+              "ControlProtocolList": {
+                "ControlProtocol": [
+                  {
+                    "streamingTransport": "RTSP"
+                  },
+                  {
+                    "streamingTransport": "HTTP"
+                  },
+                  {
+                    "streamingTransport": "SHTTP"
+                  }
+                ]
+              },
+              "Unicast": {
+                "enabled": "true",
+                "rtpTransportType": "RTP/TCP"
+              },
+              "Multicast": {
+                "enabled": "true",
+                "destIPAddress": "239.0.0.1",
+                "videoDestPortNo": "8878",
+                "audioDestPortNo": "8880"
+              },
+              "Security": {
+                "enabled": "true",
+                "certificateType": "digest",
+                "SecurityAlgorithm": {
+                  "algorithmType": "MD5"
+                }
+              },
+              "SRTPMulticast": {
+                "SRTPVideoDestPortNo": "18878",
+                "SRTPAudioDestPortNo": "18880"
+              }
+            },
+            "Video": {
+              "enabled": "true",
+              "videoInputChannelID": "2",
+              "videoCodecType": "H.264",
+              "videoScanType": "progressive",
+              "videoResolutionWidth": "640",
+              "videoResolutionHeight": "512",
+              "videoQualityControlType": "CBR",
+              "constantBitRate": "2048",
+              "fixedQuality": "60",
+              "maxFrameRate": "2500",
+              "keyFrameInterval": "2000",
+              "snapShotImageType": "JPEG",
+              "H264Profile": "High",
+              "GovLength": "50",
+              "SVC": {
+                "enabled": "false"
+              },
+              "PacketType": [
+                "PS",
+                "RTP"
+              ],
+              "smoothing": "50",
+              "IntelligentInfoDisplayMethod": "non-player"
+            },
+            "Audio": {
+              "enabled": "false",
+              "audioInputChannelID": "1",
+              "audioCompressionType": "G.711ulaw"
+            }
+          }
+        }
+      },
+      "Streaming/channels/204": {
+        "response": {
+          "StreamingChannel": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "204",
+            "channelName": "Camera 02",
+            "enabled": "true",
+            "Transport": {
+              "maxPacketSize": "1000",
+              "ControlProtocolList": {
+                "ControlProtocol": [
+                  {
+                    "streamingTransport": "RTSP"
+                  },
+                  {
+                    "streamingTransport": "HTTP"
+                  },
+                  {
+                    "streamingTransport": "SHTTP"
+                  }
+                ]
+              },
+              "Unicast": {
+                "enabled": "true",
+                "rtpTransportType": "RTP/TCP"
+              },
+              "Multicast": {
+                "enabled": "true",
+                "destIPAddress": "239.0.0.1",
+                "videoDestPortNo": "8878",
+                "audioDestPortNo": "8880"
+              },
+              "Security": {
+                "enabled": "true",
+                "certificateType": "digest",
+                "SecurityAlgorithm": {
+                  "algorithmType": "MD5"
+                }
+              },
+              "SRTPMulticast": {
+                "SRTPVideoDestPortNo": "18878",
+                "SRTPAudioDestPortNo": "18880"
+              }
+            },
+            "Video": {
+              "enabled": "true",
+              "videoInputChannelID": "2",
+              "videoCodecType": "H.264",
+              "videoScanType": "progressive",
+              "videoResolutionWidth": "640",
+              "videoResolutionHeight": "512",
+              "videoQualityControlType": "CBR",
+              "constantBitRate": "2048",
+              "fixedQuality": "60",
+              "maxFrameRate": "2500",
+              "keyFrameInterval": "2000",
+              "snapShotImageType": "JPEG",
+              "H264Profile": "High",
+              "GovLength": "50",
+              "SVC": {
+                "enabled": "false"
+              },
+              "PacketType": [
+                "PS",
+                "RTP"
+              ],
+              "smoothing": "50",
+              "IntelligentInfoDisplayMethod": "non-player"
+            },
+            "Audio": {
+              "enabled": "false",
+              "audioInputChannelID": "1",
+              "audioCompressionType": "G.711ulaw"
+            }
+          }
+        }
+      },
+      "System/Video/inputs/channels/2/motionDetection": {
+        "response": {
+          "MotionDetection": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "enabled": "true",
+            "enableHighlight": "true",
+            "samplingInterval": "2",
+            "startTriggerTime": "500",
+            "endTriggerTime": "500",
+            "regionType": "grid",
+            "Grid": {
+              "rowGranularity": "18",
+              "columnGranularity": "22"
+            },
+            "MotionDetectionLayout": {
+              "@version": "2.0",
+              "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+              "sensitivityLevel": "20",
+              "layout": {
+                "gridMap": "0000000000000000000000380000380000382000387cfff8fcfff8fcfff8fffff8fffff8fffff8fffff8fffff87ffff83ffff83ffff8"
+              }
+            }
+          }
+        }
+      },
+      "Event/triggers/VMD-1": {
+        "response": {
+          "EventTrigger": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": ["VMD-1", "VMD-1"],
+            "eventType": ["VMD", "VMD-1"],
+            "eventDescription": ["VMD Event trigger Information", "exception Information"],
+            "EventTriggerNotificationList": {
+              "EventTriggerNotification": [
+                {
+                  "id": "record-1",
+                  "notificationMethod": "record",
+                  "notificationRecurrence": "beginning",
+                  "videoInputID": "1"
+                },
+                {
+                  "id": "beep",
+                  "notificationMethod": "beep",
+                  "notificationRecurrence": "beginning"
+                },
+                {
+                  "id": "center",
+                  "notificationMethod": "center",
+                  "notificationRecurrence": "beginning"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Event/triggers/VMD-2": {
+        "response": {
+          "EventTrigger": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": ["VMD-2", "VMD-2"],
+            "eventType": ["VMD", "VMD-2"],
+            "eventDescription": ["VMD Event trigger Information", "exception Information"],
+            "EventTriggerNotificationList": {
+              "EventTriggerNotification": [
+                {
+                  "id": "IO-1",
+                  "notificationMethod": "IO",
+                  "notificationRecurrence": "beginning",
+                  "outputIOPortID": "1"
+                },
+                {
+                  "id": "record-1",
+                  "notificationMethod": "record",
+                  "notificationRecurrence": "beginning",
+                  "videoInputID": "1"
+                },
+                {
+                  "id": "FTP",
+                  "notificationMethod": "FTP",
+                  "notificationRecurrence": "beginning"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Event/triggers/scenechangedetection-2": {
+        "response": {
+          "EventTrigger": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": ["scenechangedetection-2", "scenechangedetection-2"],
+            "eventType": ["scenechangedetection", "scenechangedetection-2"],
+            "eventDescription": ["scenechangedetection Event trigger Information", "exception Information"],
+            "EventTriggerNotificationList": null
+          }
+        }
+      },
+      "Event/triggers/fielddetection-2": {
+        "status_code": 403
+      },
+      "Event/triggers/linedetection-2": {
+        "status_code": 403
+      },
+      "Event/triggers/regionentrance-2": {
+        "status_code": 403
+      },
+      "Event/triggers/regionexiting-2": {
+        "status_code": 403
+      },
+      "Event/triggers/IO-2": {
+        "status_code": 400
+      },
+      "Event/triggers/tamper-1": {
+        "response": {
+          "EventTrigger": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": ["tamper-1", "tamper-1"],
+            "eventType": ["tamperdetection", "tamper-1"],
+            "eventDescription": ["shelteralarm Event trigger Information", "exception Information"],
+            "EventTriggerNotificationList": null
+          }
+        }
+      },
+      "Event/triggers/tamper-2": {
+        "response": {
+          "EventTrigger": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": ["tamper-2", "tamper-2"],
+            "eventType": ["tamperdetection", "tamper-2"],
+            "eventDescription": ["shelteralarm Event trigger Information", "exception Information"],
+            "EventTriggerNotificationList": null
+          }
+        }
+      },
+      "Event/triggers/IO-1": {
+        "response": {
+          "EventTrigger": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": ["IO-1", "IO-1"],
+            "eventType": ["IO", "IO-1"],
+            "eventDescription": ["IO Event trigger Information", "exception Information"],
+            "inputIOPortID": "1",
+            "EventTriggerNotificationList": null
+          }
+        }
+      },
+      "Event/triggers/thermometry-1": {
+        "status_code": 403
+      },
+      "Thermal/channels/2/thermometry/basicParam": {
+        "response": {
+          "ThermometryBasicParam": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "2",
+            "enabled": "false",
+            "streamOverlay": "true",
+            "pictureOverlay": "false",
+            "pictureOverlayHeatMap": "false",
+            "temperatureRange": "-20~150",
+            "temperatureUnit": "degreeCentigrade",
+            "emissivity": "0.96",
+            "distanceUnit": "centimeter",
+            "specialPointThermType": "centerPoint",
+            "distance": "100",
+            "reflectiveEnable": "false",
+            "alert": "45.0",
+            "alarm": "55.0",
+            "showTempStripEnable": "false",
+            "AlertOutputIOPortList": {
+              "OutputIOPort": {
+                "portID": "1",
+                "enabled": "false"
+              }
+            },
+            "AlarmOutputIOPortList": {
+              "OutputIOPort": {
+                "portID": "1",
+                "enabled": "false"
+              }
+            },
+            "alertFilteringTime": "0",
+            "alarmFilteringTime": "0",
+            "displayMaxTemperatureEnabled": "true",
+            "displayMinTemperatureEnabled": "false",
+            "displayAverageTemperatureEnabled": "false",
+            "thermometryInfoDisplayposition": "rules_around",
+            "emissivityMode": "customsettings",
+            "displayTemperatureInOpticalChannelEnabled": "false",
+            "calibrationFileVersion": "V1.0.0.0 build210610",
+            "alarmInterval": "3",
+            "rulesOverlayMode": "all",
+            "alarmMode": "alarm_alert",
+            "NormalRulesColor": {
+              "R": "0",
+              "G": "255",
+              "B": "0"
+            },
+            "toleranceTemperature": "3.0",
+            "SunReflectionBlur": {
+              "enabled": "false",
+              "sensitivity": "50",
+              "filterEnabled": "false",
+              "fireFilterEnabled": "true",
+              "fireFluctuationThreshold": "1",
+              "fireFluctuationPercentage": "25"
+            },
+            "displayRuleNameEnabled": "false",
+            "imgQuality": "best",
+            "pixelToPixelOverlay": "false",
+            "refreshPixelToPixeDataIntervalTime": "3",
+            "smokingFilter": {
+              "enabled": "false",
+              "sensitivity": "50",
+              "filterEnabled": "true",
+              "smokingDetectionThreshold": "1000",
+              "smokingAreaThreshold": "10"
+            },
+            "skyFilter": {
+              "enabled": "false",
+              "filterTemperature": "25.0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/devices/DS-2TD1228-2-QA.json
+++ b/tests/fixtures/devices/DS-2TD1228-2-QA.json
@@ -651,6 +651,21 @@
                   }
                 },
                 {
+                  "id": "VMD-2",
+                  "eventType": "VMD",
+                  "eventDescription": "VMD Event trigger Information",
+                  "videoInputChannelID": "2",
+                  "EventTriggerNotificationList": {
+                    "EventTriggerNotification": [
+                      {
+                        "id": "center",
+                        "notificationMethod": "center",
+                        "notificationRecurrence": "beginning"
+                      }
+                    ]
+                  }
+                },
+                {
                   "id": "tamper-1",
                   "eventType": "tamperdetection",
                   "eventDescription": "shelteralarm Event trigger Information",
@@ -1712,6 +1727,27 @@
                 }
               }
             ]
+          }
+        }
+      },
+      "Event/triggers/VMD-2": {
+        "response": {
+          "EventTrigger": {
+            "@version": "2.0",
+            "@xmlns": "http://www.isapi.org/ver20/XMLSchema",
+            "id": "VMD-2",
+            "eventType": "VMD",
+            "eventDescription": "VMD Event trigger Information",
+            "videoInputChannelID": "2",
+            "EventTriggerNotificationList": {
+              "EventTriggerNotification": [
+                {
+                  "id": "center",
+                  "notificationMethod": "center",
+                  "notificationRecurrence": "beginning"
+                }
+              ]
+            }
           }
         }
       }

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -208,3 +208,39 @@ async def test_ipc_multichannel_event_switch(
     ]
     for entity_id in switch_entities:
         assert hass.states.get(entity_id)
+
+
+@pytest.mark.parametrize("init_integration", ["DS-2TD1228-2-QA-V5.5.338"], indirect=True)
+async def test_thermal_camera_event_type_as_list(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test thermal camera with eventType as list (firmware V5.5.338+).
+
+    Firmware V5.5.338 changed the Event/triggers response format:
+    - Old: "eventType": "VMD" (string)
+    - New: "eventType": ["VMD", "vmd-1"] (list)
+
+    This test verifies the fix in isapi.py handles this correctly.
+    """
+    device: HikvisionDevice = init_integration.runtime_data
+
+    # Verify device loaded successfully (2 channels: optical + thermal)
+    assert len(device.cameras) == 2
+
+    # Check that IO events were correctly parsed from list format
+    # device.events_info only contains IO events (EVENT_IO type)
+    io_events = [e for e in device.events_info if e.id == "io"]
+    assert len(io_events) > 0, "IO events should be parsed from list format"
+    assert any(e.io_port_id == 1 for e in io_events), "IO port 1 should exist"
+
+    # Check that VMD→motiondetection event was correctly parsed from list format
+    # Camera events are in supported_events, filtered by channel for camera.events_info
+    motion_events = [e for e in device.supported_events if e.id == "motiondetection"]
+    assert len(motion_events) > 0, "VMD event should be parsed as motiondetection from list format"
+
+    # Check that thermometry is now a separate event type (not mapped to motiondetection)
+    thermometry_events = [e for e in device.supported_events if e.id == "thermometry"]
+    assert len(thermometry_events) > 0, "Thermometry should be a separate event type"
+    assert thermometry_events[0].channel_id == 2, "Thermometry should be on channel 2 (thermal)"
+    assert thermometry_events[0].url == "Thermal/channels/2/thermometry/basicParam"


### PR DESCRIPTION
# Fix thermal multi‑channel cameras (FW 5.5.338+): `eventType` list parsing, Thermometry support, reduced 403 spam, unique_id de‑dupe

Base: `origin/dev` → Head: `fix-thermal-camera-support-new-firmware`

## Summary
This PR addresses multiple issues seen on Hikvision thermal cameras (e.g. `DS-2TD1228-2-QA`) with newer firmware (notably `V5.5.338+`):
- Prevents integration startup crashes caused by list-valued `eventType`/`id` fields in `Event/triggers`.
- Adds proper **Thermometry** support as a first‑class event with the correct `ISAPI/Thermal/...` endpoint.
- Dramatically reduces Home Assistant log spam and unnecessary polling when certain endpoints always return **403 Forbidden**.
- Fixes Home Assistant warnings about **duplicate unique IDs** by de‑duplicating event capabilities by computed unique_id.
- Improves clarity for multi‑channel devices by adding `(Ch. X)` to entity names.

---

## Background / Symptoms

### 1) Crash on initialization (FW 5.5.338+)
Observed error:
- `AttributeError: 'list' object has no attribute 'lower'`

Root cause:
- Newer firmwares can return `eventType` (and sometimes `id`) as a list, e.g. `["VMD", "VMD-1"]`, while the integration assumed a string and called `.lower()` directly.

### 2) Massive repeated 403 log spam (10k+ entries)
Typical log patterns:
- `Forbidden request https://.../ISAPI/Smart/FieldDetection/2, check user permissions.`
- `Forbidden access | https://... | Cannot fetch state for fielddetection | ... 403 Forbidden ...`

Root cause:
- The integration polls “enabled” state for events on a fixed interval (120s). Some devices/firmwares return persistent 403 for certain endpoints (feature not available on that channel, API gating, or permission semantics), which was retried and logged indefinitely.

### 3) Thermometry handled incorrectly
Root cause:
- `thermometry` was incorrectly mapped to `motiondetection` via alternate IDs.
- Thermal parameters live under `ISAPI/Thermal/channels/{channel_id}/...`, not `ISAPI/Smart/...`.

### 4) Home Assistant warnings: duplicate unique IDs
Typical HA warning:
- “Platform hikvision_next does not generate unique IDs. ID ... is already used ... ignoring ...”

Root cause:
- Duplicate `EventInfo` entries could result in duplicate computed unique IDs being emitted to HA.

---

## What changed (technical detail)

## 1) Robust event parsing for FW 5.5.338+ (`eventType`/`id` lists)
**File:** `custom_components/hikvision_next/isapi/isapi.py` (`ISAPIClient.get_supported_events()`)

Changes:
- Normalize `eventType` into a list of candidate strings (supports:
  - string values,
  - list values,
  - dict values with `{"#text": ...}`).
- Select the first candidate that normalizes into a known integration event ID:
  - supports alternate IDs (e.g. `VMD` → `motiondetection`),
  - supports hyphen variants (e.g. `VMD-1` → prefix resolution).
- If `videoInputChannelID` is missing, derive `channel_id` from the trigger `id` (e.g. `VMD-1` → channel `1`).

Why:
- Prevents initialization crashes and ensures correct channel association for multi‑channel thermal devices.

---

## 2) Multi‑channel event discovery: correct `Event/triggers/{prefix}-{channel}` requests
**File:** `custom_components/hikvision_next/isapi/isapi.py` (`ISAPIClient.get_supported_events()`)

Problem:
- `Event/channels/capabilities` can use event type names that don’t match the `Event/triggers/*` ID scheme expected by the camera (e.g. capabilities show `motionDetection` but triggers require `VMD-1`).

Fix:
- Build an `event_url_prefix_map` from the `Event/triggers` list response:
  - map `eventType` to the actual prefix derived from `EventTrigger.id`,
  - also map translated integration IDs (e.g. `motiondetection`) to that prefix.
- When iterating channel capabilities, request `Event/triggers/{prefix}-{channel_id}` using the map.
- Skip IO in this per-channel loop (`EVENT_IO` is not a per video channel event here).

Fallback behavior:
- If the per-channel trigger request fails during init (e.g. returns `{}` due to init-time error suppression), still create a minimal `EventInfo` from capabilities to keep the integration usable.

Why:
- Fixes multi-channel discovery for thermal devices where the naming mismatch otherwise causes wrong URLs and cascades into repeated 403s.

---

## 3) Thermometry is now a first‑class thermal event (`ISAPI/Thermal/...`)
**Files:**
- `custom_components/hikvision_next/isapi/const.py`
- `custom_components/hikvision_next/isapi/isapi.py`
- `custom_components/hikvision_next/const.py`
- `custom_components/hikvision_next/translations/en.json`

Changes:
- Introduce `EVENT_THERMAL`.
- Define `thermometry` as:
  - `type = EVENT_THERMAL`
  - `slug = thermometry/basicParam`
- Remove the incorrect alternate mapping `thermometry → motiondetection`.
- Update `get_event_url()` to generate thermal paths:
  - `Thermal/channels/{channel_id}/thermometry/basicParam`
- Expose `thermometry` in integration-level `EVENTS` with `BinarySensorDeviceClass.HEAT`.
- Add translations for `pir` and `thermometry` in EN for both binary_sensor and switch.

Why:
- Thermometry is not motion detection and needs a different endpoint family.

---

## 4) Reduce 403 spam: cache forbidden endpoints for polling (but bypass for user actions)
**Files:**
- `custom_components/hikvision_next/isapi/isapi.py`
- `custom_components/hikvision_next/hikvision_device.py`
- `custom_components/hikvision_next/services.py`

Changes:
- Add `_forbidden_cache` in `ISAPIClient` keyed by `"{METHOD} {full_url}"`.
- `ISAPIClient.request()` gained `use_forbidden_cache: bool = True`:
  - If a URL is cached as forbidden (and we’re past initialization), subsequent polling calls short-circuit immediately with `ISAPIForbiddenError(..., suppressed=True)` **without sending HTTP requests**.
  - On success, the cache entry is removed.
  - On first post-init 403, the URL is added to the cache.
- `ISAPIForbiddenError` no longer logs directly in its constructor (prevents double logging); it also supports synthetic/suppressed instances.
- `HikvisionDevice.handle_exception()` ignores suppressed forbidden errors to eliminate log spam.
- Explicit actions bypass the cache (`use_forbidden_cache=False`) so users can immediately re-test after permission/config changes:
  - write/update operations (switch toggles, mutex checks, holiday/alarm server setters, reboot),
  - the custom `hikvision_next.request` service.

Why:
- Prevents endless retries/log spam for endpoints that permanently return 403 during polling, while keeping manual control responsive.

---

## 5) De‑duplicate event capabilities by computed unique_id (fix HA warnings)
**File:** `custom_components/hikvision_next/hikvision_device.py` (`get_device_event_capabilities()`)

Changes:
- Build fresh `EventInfo` instances for integration usage (avoid mutating shared objects).
- De‑duplicate by computed unique_id.
- Merge notification methods; recompute `disabled` consistently.
- Preserve/merge best-known `url` and `is_proxy` across duplicates.

Why:
- Prevents “duplicate unique ID” warnings and HA ignoring entities on multi-channel devices.

---

## 6) Clearer naming for multi‑channel entities
**Files:**
- `custom_components/hikvision_next/binary_sensor.py`
- `custom_components/hikvision_next/switch.py`

Changes:
- For multi‑channel devices, add channel suffix to display names:
  - Binary sensor: `"{Label} (Ch. X)"`
  - Switch: `"{Label} Detection (Ch. X)"`

Why:
- Thermal devices present multiple channels (optical + thermal); this avoids ambiguous entity names in the UI.

---

## Minor fix
**File:** `custom_components/hikvision_next/isapi/isapi.py`
- Fix an f-string quoting issue in the serial-number fallback path for proxied cameras.

---

## Tests / Fixtures

### Fixtures
- New firmware fixture capturing FW `V5.5.338+` behavior:
  - `tests/fixtures/devices/DS-2TD1228-2-QA-V5.5.338.json` (includes list-valued `eventType`/`id` and various 403/400 responses)
- Older fixture updated:
  - `tests/fixtures/devices/DS-2TD1228-2-QA.json` now includes missing `VMD-2` and a corresponding `Event/triggers/VMD-2` response.

### Tests
- `tests/test_switch.py` adds a dedicated test to verify:
  - integration initializes successfully with `eventType` as a list,
  - `VMD` maps to `motiondetection`,
  - `thermometry` exists as a separate event and uses the correct thermal URL.

Note:
- `tests/test_switch.py` currently has CRLF line endings (functionality is unaffected, but linters may care).

---

## Behavior / Compatibility Notes
- 403 caching affects polling only:
  - You should see at most one warning per forbidden endpoint per runtime; subsequent polls are suppressed and the device is not hammered.
  - Manual actions and the custom ISAPI request service bypass the cache for immediate re-testing.
- Thermometry is a new first-class event:
  - thermal devices may gain new `thermometry` entities.
- Multi-channel display names change (adds `(Ch. X)`), unique IDs remain stable.
