### PR TITLE
Fix invalid entity IDs and wrong snapshot entity domain

### DIFF
--- a/custom_components/hikvision_next/image.py
+++ b/custom_components/hikvision_next/image.py
@@ -6,7 +6,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.camera import Camera
-from homeassistant.components.image import ImageEntity
+from homeassistant.components.image import ENTITY_ID_FORMAT, ImageEntity
 from homeassistant.const import ATTR_ENTITY_ID, CONF_FILENAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
@@ -63,7 +63,7 @@ class SnapshotFile(ImageEntity):
         ImageEntity.__init__(self, hass)
 
         self._attr_unique_id = slugify(f"{device.device_info.serial_no.lower()}_{stream_info.id}_snapshot")
-        self.entity_id = f"camera.{self.unique_id}"
+        self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
         self._attr_translation_key = "snapshot"
         self._attr_translation_placeholders = {"camera": camera.name}
 

--- a/custom_components/hikvision_next/sensor.py
+++ b/custom_components/hikvision_next/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from . import HikvisionConfigEntry
 from .const import CONF_ALARM_SERVER_HOST, SECONDARY_COORDINATOR
@@ -53,7 +54,7 @@ class AlarmServerSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         device = coordinator.device
         self._attr_unique_id = f"{device.device_info.serial_no}_{CONF_ALARM_SERVER_HOST}_{key}"
-        self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
+        self.entity_id = ENTITY_ID_FORMAT.format(slugify(self.unique_id))
         self._attr_device_info = device.hass_device_info()
         self._attr_translation_key = f"notifications_host_{key}"
         self.key = key
@@ -77,7 +78,7 @@ class StorageSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         device = coordinator.device
         self._attr_unique_id = f"{device.device_info.serial_no}_{hdd.id}_{hdd.name}"
-        self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
+        self.entity_id = ENTITY_ID_FORMAT.format(slugify(self.unique_id))
         self._attr_device_info = device.hass_device_info()
         self._attr_name = f"{hdd.type} {hdd.name}"
         self.hdd = hdd

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -41,6 +41,23 @@ async def test_sensor_value_outside_network(
         assert sensor.state == state
 
 
+@pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2"], indirect=True)
+async def test_entity_id_is_valid(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that entities do not set invalid entity IDs.
+
+    The fixture serial number contains uppercase letters, hyphens and slashes,
+    which must be slugified before being used in an entity ID.
+    """
+
+    messages = [record.getMessage() for record in caplog.get_records("setup") + caplog.records]
+    assert not any("sets an invalid entity ID" in message for message in messages)
+    assert not any("sets an entity ID with wrong domain" in message for message in messages)
+
+
 @pytest.mark.parametrize("init_integration", ["DS-2CD2146G2-ISU", "DS-7608NXI-I2"], indirect=True)
 async def test_scenechange_support(
     hass: HomeAssistant,


### PR DESCRIPTION
## Summary

Two fixes for entity registration warnings/errors reported in multiple open issues:

- **Slugify the device serial number before using it in sensor entity IDs.** `AlarmServerSensor` and `StorageSensor` built `entity_id` directly from the raw serial number, which contains uppercase letters, hyphens and sometimes slashes (e.g. `DS-7608NXI-I2/S...`). Home Assistant logs `Detected that custom integration 'hikvision_next' sets an invalid entity ID` (breaking in HA 2027.2), and on recent HA versions with strict validation these sensors fail to be added at all (`HomeAssistantError: Invalid entity ID`). Unique IDs are intentionally left untouched so existing entity registry entries are preserved for current users.
- **Register snapshot image entities under the `image` domain instead of `camera`.** `SnapshotFile` set `entity_id` with a `camera.` prefix, producing `sets an entity ID with wrong domain` warnings (breaking in HA 2027.5).

Fixes #336, fixes #338, fixes #339, fixes #341, fixes #343, fixes #344, fixes #345

## Test plan

- Added a regression test that initializes the `DS-7608NXI-I2` fixture (serial `DS-7608NXI-I0/0P/S...WCVU`, which contains uppercase letters, hyphens and slashes) and asserts that neither warning is emitted during setup. The test fails without the fix and passes with it.
- Full test suite passes on top of `dev`: 74 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)