### PR TITLE
Fix camera entities failing to load on HA 2026.9 (via_device)

### DIFF
--- a/custom_components/hikvision_next/hikvision_device.py
+++ b/custom_components/hikvision_next/hikvision_device.py
@@ -105,14 +105,40 @@ class HikvisionDevice(ISAPIClient):
             camera_info = self.get_camera_by_id(camera_id)
             is_ip_camera = isinstance(camera_info, IPCamera)
 
-            return DeviceInfo(
+            device_info = DeviceInfo(
                 manufacturer=self.device_info.manufacturer,
                 identifiers={(DOMAIN, camera_info.serial_no)},
                 model=camera_info.model,
                 name=camera_info.name,
                 sw_version=camera_info.firmware if is_ip_camera else "Unknown",
-                via_device=(DOMAIN, self.device_info.serial_no) if self.device_info.is_nvr else None,
             )
+
+            if self.device_info.is_nvr:
+                self._link_to_nvr(device_info)
+
+            return device_info
+
+    def _link_to_nvr(self, device_info: DeviceInfo) -> None:
+        """Link a camera device to the NVR it belongs to.
+
+        Home Assistant 2026.9 removed `via_device` from DeviceInfo and made the device registry
+        raise on it, so on those cores the key must be absent rather than None: the registry
+        reports it as soon as it is passed, whatever its value. Its replacement `via_device_id`,
+        and the lookup needed to fill it, only arrived in 2026.8, so both spellings are kept
+        while older cores are supported.
+        """
+        registry = dr.async_get(self.hass)
+        identifier = (DOMAIN, self.device_info.serial_no)
+
+        if hasattr(registry, "async_get_device_by_identifier"):
+            # async_setup_entry registers the NVR before it forwards the platforms, so the
+            # lookup finds it. Without a match the camera is still created, only unlinked.
+            if self.entry:
+                nvr_device = registry.async_get_device_by_identifier(identifier, self.entry.entry_id)
+                if nvr_device:
+                    device_info["via_device_id"] = nvr_device.id
+        else:
+            device_info["via_device"] = identifier
 
     def get_device_event_capabilities(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,6 +3,7 @@
 import pytest
 from unittest.mock import patch
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from custom_components.hikvision_next.const import DOMAIN
 from custom_components.hikvision_next.hikvision_device import HikvisionDevice
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -39,6 +40,42 @@ async def test_basic_init(hass: HomeAssistant, init_integration: MockConfigEntry
     device: HikvisionDevice = entry.runtime_data
     assert device.host == TEST_CONFIG["host"]
     assert init_integration.title in device.device_info.model
+
+
+@pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2"], indirect=True)
+async def test_nvr_cameras_are_linked_to_the_nvr(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test camera devices of an NVR are linked to the NVR device."""
+
+    entry = init_integration
+    device: HikvisionDevice = entry.runtime_data
+    device_registry = dr.async_get(hass)
+
+    nvr_device = device_registry.async_get_device(identifiers={(DOMAIN, device.device_info.serial_no)})
+    assert nvr_device
+
+    camera_devices = [
+        entry_device
+        for entry_device in dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        if entry_device.id != nvr_device.id
+    ]
+    assert camera_devices
+
+    for camera_device in camera_devices:
+        assert camera_device.via_device_id == nvr_device.id
+
+
+@pytest.mark.parametrize("init_integration", ["DS-2CD2386G2-IU"], indirect=True)
+async def test_standalone_camera_is_not_linked(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test a standalone IP camera is not linked to another device."""
+
+    entry = init_integration
+    device_registry = dr.async_get(hass)
+
+    devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+    assert devices
+
+    for camera_device in devices:
+        assert camera_device.via_device_id is None
 
 
 @pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2"], indirect=True)


### PR DESCRIPTION
Fixes #365
Fixes #366

On Home Assistant 2026.9 none of my NVR cameras loaded any more. 17 of my 18 camera entities
went `unavailable`, with one error per entity:

```
Error adding entity camera.… for domain camera with platform hikvision_next
RuntimeError: Detected code that calls `device_registry.async_get_or_create`
with a deprecated `via_device` parameter; use `via_device_id` instead.
```

The recorder itself was fine, all `videoloss` sensors stayed `off`.

### What changed in Home Assistant

In 2026.9 `entity_platform` forwards `DeviceInfo` to `async_get_or_create` unchanged, and the
registry reports `via_device` with `core_behavior=ReportBehavior.ERROR`. By then the call chain
holds no integration frame, so `frame._report_usage_no_integration` takes the `ERROR` path and
raises `RuntimeError` instead of logging a warning. The entity is never added.

### Why `else None` did not help

`hass_device_info` passed the key unconditionally:

```python
via_device=(DOMAIN, self.device_info.serial_no) if self.device_info.is_nvr else None,
```

The registry pops the parameter and reports it as soon as it is present, whatever its value.
The key has to be absent, not `None`.

### Compatibility

I compared `homeassistant/helpers/device_registry.py` across release tags:

| HA version | `via_device` in `DeviceInfo` | `via_device_id` in `async_get_or_create` | `async_get_device_by_identifier` |
|---|---|---|---|
| 2026.9.0 | removed, reported as an error | yes | yes |
| 2026.8.0 | yes | yes | yes |
| 2026.6.0 and older | yes | no | no |

There is no single spelling that works on both 2026.6 and 2026.9. `hacs.json` declares 2022.8,
and CI runs Python 3.12, which resolves `pytest-homeassistant-custom-component` to Home
Assistant 2025.1.4. So this PR keeps both spellings and picks one at runtime, rather than
raising the minimum version. Say the word if you would rather bump `hacs.json` to `2026.8` and
drop the branch, I am happy to change it.

### The change

The linking moves into `_link_to_nvr`:

```python
registry = dr.async_get(self.hass)
identifier = (DOMAIN, self.device_info.serial_no)

if hasattr(registry, "async_get_device_by_identifier"):
    if self.entry:
        nvr_device = registry.async_get_device_by_identifier(identifier, self.entry.entry_id)
        if nvr_device:
            device_info["via_device_id"] = nvr_device.id
else:
    device_info["via_device"] = identifier
```

`async_setup_entry` registers the NVR before it forwards the platforms, so the lookup finds it.
Without a match the camera entity is still created, only unlinked.

I used `async_get_device_by_identifier` rather than `async_get_device`, because the latter is
deprecated as well and warns on 2026.9. It also scopes the lookup to the config entry.
`self.entry` can be `None`, since `HikvisionDevice` is also built from the config flow.

### This keeps the device tree

Commenting the line out, as suggested in #365, loads the cameras but leaves them without a
parent, so every camera becomes a standalone device. That side effect is described in #366.
With this change the cameras stay grouped under the NVR.

### Tests

Two tests in `tests/test_init.py`: camera devices of an NVR carry `via_device_id` pointing at
the NVR device, and a standalone IP camera stays unlinked. Both go through the old spelling on
CI and through the new one on 2026.9.

`pytest` on the branch: 75 passed.

### Verified on

Home Assistant 2026.9.0 with a DS-7716NI-K4/16P and 9 cameras. After the change every camera
entity is back, no entity id changed, and all cameras are grouped under the recorder again.

### Not in this PR

#365 also mentions the snapshot entities using the `camera` domain where `image` is expected.
That is a separate migration and I left it alone.
