### PR TITLE
Fix camera entities failing to load on HA 2026.9

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,7 +1,10 @@
 name: CI
 
 on:
+  push:
   pull_request:
+  schedule:
+    - cron: "0 3 * * *"
 
 jobs:
   build:
@@ -9,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+.idea/
+.venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ NOTE: the first container build and launch Home Assistant may take longer.
 
 ## Test Environment
 
-Install python 3.12 or later and project dependencies:
+Install python 3.14 or later and project dependencies:
 ```
 pip install -r requirements.test.txt
 ```

--- a/custom_components/hikvision_next/__init__.py
+++ b/custom_components/hikvision_next/__init__.py
@@ -53,7 +53,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: HikvisionConfigEntry) ->
         await device.get_hardware_info()
         device_info = device.hass_device_info()
         device_registry = dr.async_get(hass)
-        device_registry.async_get_or_create(config_entry_id=entry.entry_id, **device_info)
+        device_entry = device_registry.async_get_or_create(config_entry_id=entry.entry_id, **device_info)
+        device.root_device_id = device_entry.id
     except ISAPIUnauthorizedError as ex:
         raise ConfigEntryAuthFailed from ex
     except Exception as ex:  # pylint: disable=broad-except
@@ -121,14 +122,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     if config_entry.version == 1:
         unique_id = config_entry.unique_id
         if isinstance(unique_id, list) and len(unique_id) == 1 and isinstance(unique_id[0], list):
-            new_unique_id = unique_id[0][1]
-            hass.config_entries.async_update_entry(
-                config_entry,
-                data={**config_entry.data},
-                unique_id=new_unique_id,
-            )
+            unique_id = unique_id[0][1]
 
-        config_entry.version = 2
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={**config_entry.data},
+            unique_id=unique_id,
+            version=2,
+        )
 
     # 2 -> 3: Delete previous alaram server sensor entities
     if config_entry.version == 2:

--- a/custom_components/hikvision_next/hikvision_device.py
+++ b/custom_components/hikvision_next/hikvision_device.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util import slugify
 
@@ -64,6 +64,7 @@ class HikvisionDevice(ISAPIClient):
         super().__init__(host, username, password, verify_ssl, rtsp_port_forced, session)
 
         self.events_info: list[EventInfo] = []
+        self.root_device_id: str | None = None
 
     async def init_coordinators(self):
         """Initialize coordinators."""
@@ -103,16 +104,31 @@ class HikvisionDevice(ISAPIClient):
             )
         else:
             camera_info = self.get_camera_by_id(camera_id)
+            if camera_info is None:
+                return DeviceInfo(identifiers={(DOMAIN, self.device_info.serial_no)})
+
             is_ip_camera = isinstance(camera_info, IPCamera)
 
-            return DeviceInfo(
+            device_info = DeviceInfo(
                 manufacturer=self.device_info.manufacturer,
                 identifiers={(DOMAIN, camera_info.serial_no)},
                 model=camera_info.model,
                 name=camera_info.name,
                 sw_version=camera_info.firmware if is_ip_camera else "Unknown",
-                via_device=(DOMAIN, self.device_info.serial_no) if self.device_info.is_nvr else None,
             )
+
+            # Nest the camera under the NVR. The deprecated via_device key must be absent,
+            # not None - the device registry reports it as soon as it is passed.
+            if (
+                self.device_info.is_nvr
+                and self.root_device_id
+                # A device cannot be its own via device. NVRs sometimes report the recorder
+                # serial for a channel, see get_cameras() serial number fallbacks.
+                and camera_info.serial_no != self.device_info.serial_no
+            ):
+                device_info["via_device_id"] = self.root_device_id
+
+            return device_info
 
     def get_device_event_capabilities(
         self,

--- a/custom_components/hikvision_next/image.py
+++ b/custom_components/hikvision_next/image.py
@@ -5,8 +5,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.camera import Camera
-from homeassistant.components.image import ImageEntity
+from homeassistant.components.image import ENTITY_ID_FORMAT, ImageEntity
 from homeassistant.const import ATTR_ENTITY_ID, CONF_FILENAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
@@ -17,7 +16,7 @@ from homeassistant.util import slugify
 from . import HikvisionConfigEntry
 from .const import ACTION_UPDATE_SNAPSHOT
 from .hikvision_device import HikvisionDevice
-from .isapi import CameraStreamInfo
+from .isapi import AnalogCamera, CameraStreamInfo
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,7 +54,7 @@ class SnapshotFile(ImageEntity):
         self,
         hass: HomeAssistant,
         device: HikvisionDevice,
-        camera: Camera,
+        camera: AnalogCamera,
         stream_info: CameraStreamInfo,
     ) -> None:
         """Initialize the snapshot file."""
@@ -63,7 +62,7 @@ class SnapshotFile(ImageEntity):
         ImageEntity.__init__(self, hass)
 
         self._attr_unique_id = slugify(f"{device.device_info.serial_no.lower()}_{stream_info.id}_snapshot")
-        self.entity_id = f"camera.{self.unique_id}"
+        self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
         self._attr_translation_key = "snapshot"
         self._attr_translation_placeholders = {"camera": camera.name}
 

--- a/custom_components/hikvision_next/manifest.json
+++ b/custom_components/hikvision_next/manifest.json
@@ -13,5 +13,5 @@
     "xmltodict==0.13.0",
     "requests-toolbelt==1.0.0"
   ],
-  "version": "1.1.1"
+  "version": "1.1.2"
 }

--- a/custom_components/hikvision_next/sensor.py
+++ b/custom_components/hikvision_next/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from . import HikvisionConfigEntry
 from .const import CONF_ALARM_SERVER_HOST, SECONDARY_COORDINATOR
@@ -53,7 +54,7 @@ class AlarmServerSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         device = coordinator.device
         self._attr_unique_id = f"{device.device_info.serial_no}_{CONF_ALARM_SERVER_HOST}_{key}"
-        self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
+        self.entity_id = ENTITY_ID_FORMAT.format(slugify(self.unique_id))
         self._attr_device_info = device.hass_device_info()
         self._attr_translation_key = f"notifications_host_{key}"
         self.key = key
@@ -77,7 +78,7 @@ class StorageSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         device = coordinator.device
         self._attr_unique_id = f"{device.device_info.serial_no}_{hdd.id}_{hdd.name}"
-        self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
+        self.entity_id = ENTITY_ID_FORMAT.format(slugify(self.unique_id))
         self._attr_device_info = device.hass_device_info()
         self._attr_name = f"{hdd.type} {hdd.name}"
         self.hdd = hdd

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Hikvision NVR / IP Camera",
   "render_readme": true,
-  "homeassistant": "2022.8"
+  "homeassistant": "2026.8"
 }

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -6,10 +6,12 @@ requests-toolbelt==1.0.0
 pytest
 pytest-asyncio
 pytest-cov>=4.1.0
-pytest-homeassistant-custom-component>=0.13.179
+pytest-homeassistant-custom-component>=0.13.363
 
 #
 async-timeout
 httpx
 respx
 aiohttp_cors
+# required by homeassistant.components.camera since HA 2026.9
+PyTurboJPEG==1.8.3

--- a/run_test.dockerfile
+++ b/run_test.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.14
 ENV PIP_DISABLE_ROOT_WARNING=1
 RUN python -m pip install --upgrade pip
 COPY requirements.test.txt requirements.txt

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,58 @@
+"""Tests for image platform."""
+
+import pytest
+from homeassistant.components.image import DATA_COMPONENT, DOMAIN as IMAGE_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, CONF_FILENAME, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.hikvision_next.const import ACTION_UPDATE_SNAPSHOT, DOMAIN
+
+SNAPSHOT_ENTITIES = [
+    "image.ds_7608nxi_i0_0p_s0000000000ccrrj00000000wcvu_101_snapshot",
+    "image.ds_7608nxi_i0_0p_s0000000000ccrrj00000000wcvu_201_snapshot",
+    "image.ds_7608nxi_i0_0p_s0000000000ccrrj00000000wcvu_301_snapshot",
+]
+
+
+@pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2"], indirect=True)
+async def test_snapshot_entities(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test snapshot entities are registered in the image domain."""
+
+    entity_registry = er.async_get(hass)
+
+    assert sorted(hass.states.async_entity_ids(IMAGE_DOMAIN)) == SNAPSHOT_ENTITIES
+
+    for entity_id in SNAPSHOT_ENTITIES:
+        assert (entity := entity_registry.async_get(entity_id))
+        assert entity.platform == DOMAIN
+
+    # snapshots used to set a camera. entity_id, see issues #365, #366, #368
+    assert not [
+        entity_id for entity_id in hass.states.async_entity_ids("camera") if entity_id.endswith("_snapshot")
+    ]
+
+
+@pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2"], indirect=True)
+async def test_update_snapshot_action(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test the update_snapshot action renders the filename template.
+
+    The action targets the image domain, see services.yaml and the
+    take_pictures_on_motion_detection blueprint.
+    """
+
+    entity_id = SNAPSHOT_ENTITIES[0]
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        DOMAIN,
+        ACTION_UPDATE_SNAPSHOT,
+        {ATTR_ENTITY_ID: entity_id, CONF_FILENAME: "/media/{{ entity_id }}.jpg"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    entity = hass.data[DATA_COMPONENT].get_entity(entity_id)
+    assert entity.file_path == f"/media/{entity_id}.jpg"
+    assert hass.states.get(entity_id).state != STATE_UNKNOWN

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,6 +3,8 @@
 import pytest
 from unittest.mock import patch
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from custom_components.hikvision_next import async_migrate_entry
 from custom_components.hikvision_next.const import DOMAIN
 from custom_components.hikvision_next.hikvision_device import HikvisionDevice
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -188,3 +190,123 @@ async def test_async_setup_entry_nvr_outside_network(hass: HomeAssistant, init_i
     await hass.async_block_till_done()
 
     assert not hass.data.get(DOMAIN)
+
+
+@pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2", "iDS-7204HUHI-M1", "DS-2CD2386G2-IU"], indirect=True)
+async def test_device_info_without_deprecated_via_device(
+    hass: HomeAssistant, init_integration: MockConfigEntry
+) -> None:
+    """Test device info does not carry the via_device key removed in HA 2026.9."""
+
+    device: HikvisionDevice = init_integration.runtime_data
+
+    assert "via_device" not in device.hass_device_info()
+    for camera in device.cameras:
+        assert "via_device" not in device.hass_device_info(camera.id)
+
+
+@pytest.mark.parametrize(
+    ("init_integration", "linked_cameras"),
+    [("DS-7608NXI-I2", 3), ("DS-7616NI-Q2", 9)],
+    indirect=["init_integration"],
+)
+async def test_nvr_camera_devices_are_linked(
+    hass: HomeAssistant, init_integration: MockConfigEntry, linked_cameras: int
+) -> None:
+    """Test camera devices of an NVR are nested under the NVR device."""
+
+    entry = init_integration
+    device: HikvisionDevice = entry.runtime_data
+    device_registry = dr.async_get(hass)
+
+    nvr_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device.device_info.serial_no), entry.entry_id
+    )
+    assert nvr_device
+    assert nvr_device.via_device_id is None
+    assert device.root_device_id == nvr_device.id
+
+    linked = 0
+    for camera in device.cameras:
+        # a channel without entities has no device entry, ie. one with no accessible streams
+        if camera_device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, camera.serial_no), entry.entry_id
+        ):
+            assert camera_device.via_device_id == nvr_device.id
+            linked += 1
+
+    assert linked == linked_cameras
+
+
+@pytest.mark.parametrize("init_integration", ["DS-2CD2386G2-IU"], indirect=True)
+async def test_ip_camera_device_is_not_linked(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test a standalone IP camera is not nested under another device."""
+
+    entry = init_integration
+    device: HikvisionDevice = entry.runtime_data
+    device_registry = dr.async_get(hass)
+
+    for camera in device.cameras:
+        assert "via_device_id" not in device.hass_device_info(camera.id)
+
+    for device_entry in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        assert device_entry.via_device_id is None
+
+
+@pytest.mark.parametrize("init_integration", ["DS-7608NXI-I2"], indirect=True)
+async def test_camera_is_not_its_own_via_device(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test a channel reporting the NVR serial is not linked to itself.
+
+    Home Assistant raises when a device references itself as its via device.
+    """
+
+    device: HikvisionDevice = init_integration.runtime_data
+    camera = device.cameras[0]
+    camera.serial_no = device.device_info.serial_no
+
+    assert "via_device_id" not in device.hass_device_info(camera.id)
+
+
+async def test_migrate_entry_from_version_1(hass: HomeAssistant) -> None:
+    """Test migration of a config entry created before version 2.
+
+    Config entry attributes are read only, they can only be set through
+    async_update_entry, otherwise the migration fails and the entry never loads.
+    """
+
+    serial_no = "DS-7608NXI-I0/0P/S0000000000CCRRJ00000000WCVU"
+    entry = MockConfigEntry(domain=DOMAIN, data=TEST_CONFIG, version=1, unique_id=serial_no)
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+
+    assert entry.version == 3
+    assert entry.unique_id == serial_no
+
+
+@pytest.mark.parametrize(
+    "init_integration",
+    [("DS-7608NXI-I2", True), ("iDS-7208HQHI-M1", True)],
+    indirect=True,
+)
+async def test_setup_without_entity_id_deprecation_warnings(
+    hass: HomeAssistant, init_integration: MockConfigEntry, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test setup does not hit any of the deprecations reported in issues #365, #366, #368.
+
+    Home Assistant makes them fatal in 2027.8, 2027.2 and 2027.5 respectively. The
+    integration is set up here, not by the fixture, so that caplog sees the warnings.
+    """
+
+    entry = init_integration
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state == ConfigEntryState.LOADED
+
+    for message in (
+        "deprecated `via_device` parameter",
+        "sets an invalid entity ID",
+        "sets an entity ID with wrong domain",
+    ):
+        assert message not in caplog.text

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,8 @@
 """Tests for sensor platform."""
 
 import pytest
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, valid_entity_id
+from homeassistant.util import slugify
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 import homeassistant.helpers.entity_registry as er
 
@@ -69,3 +70,27 @@ async def test_scenechange_support(
     for entity_id in entities:
         assert (entity := entity_registry.async_get(entity_id))
         assert entity.disabled == data["disabled"]
+
+
+@pytest.mark.parametrize(
+    "init_integration",
+    ["DS-7608NXI-I2", "DS-2CD2T86G2-ISU", "iDS-7208HQHI-M1"],
+    indirect=True,
+)
+async def test_sensor_entity_ids_are_valid(hass: HomeAssistant, init_integration: MockConfigEntry) -> None:
+    """Test sensor entity ids are valid for serial numbers with slashes and parentheses.
+
+    The unique_id keeps the raw serial number, only the entity_id is slugified.
+    """
+
+    entity_registry = er.async_get(hass)
+    entities = [
+        entity
+        for entity in er.async_entries_for_config_entry(entity_registry, init_integration.entry_id)
+        if entity.domain == "sensor"
+    ]
+    assert entities
+
+    for entity in entities:
+        assert valid_entity_id(entity.entity_id)
+        assert entity.entity_id == f"sensor.{slugify(entity.unique_id)}"


### PR DESCRIPTION
Fixes #365, fixes #366, fixes #368.

On Home Assistant 2026.9 the integration loads but almost all camera entities disappear. On a
DS-7608NXI with 8 channels, **1 of 9 camera entities** survives setup; the other 8 fail with
``RuntimeError: Detected code that uses deprecated `via_device` parameter``.

## What was wrong

**1. `via_device` is fatal now (#365, #368).** 2026.9 removed `via_device` from `DeviceInfo` and
made the device registry report its use. The registry pops the key and reports it whenever it is
*present*, so `via_device=... if ... else None` does not help — the key has to be absent.

The report is raised, not logged, because it happens with no integration frame on the stack.
That is also why the failure looks erratic in #368. `_async_schedule_add_entities_for_entry` uses
`eager_start=True`, so the first entity is added synchronously on the integration's own stack —
frame present, warning only. Every entity after the first resumes from the event loop with no
integration frame, and `report_usage` falls through to `_report_usage_no_integration`, which
raises. Hence exactly one camera survives, and hence #368's report that it "sometimes" works.

Cameras are now linked with `via_device_id`, resolved from the `DeviceEntry` that
`async_setup_entry` already creates, so they stay grouped under the recorder in the UI. Passing a
device its own id is a hard `HomeAssistantError` on the new path, and some NVRs report the
recorder serial for a channel, so there is an explicit guard for that.

**2. Snapshot entities used a `camera.` entity id (#366).** They are served by the image platform,
so `sets an entity ID with wrong domain` — fatal in 2027.5. Now uses the image platform's
`ENTITY_ID_FORMAT`.

**3. Diagnostic sensors built entity ids from the raw serial number (#366).** Serials like
`DS-7608NXI-I2/8P/S.../HDD1` contain slashes and parentheses, so `sets an invalid entity ID` —
fatal in 2027.2. Now slugified.

Both of these are **no-ops for already-registered entities**: HA discards the domain half of an
explicitly assigned entity id, and the sensor ids were already being slugified downstream.
`unique_id` is untouched in both cases, so nothing is orphaned and no entity id changes.

**4. Config entry migration was broken.** `async_migrate_entry` assigned `config_entry.version`
directly, which 2026.9 rejects with `AttributeError`. Any entry still on version 1 could not load
at all. It now goes through `async_update_entry(..., version=2)`.

## Compatibility

**Requires Home Assistant 2026.8 or newer.** 2026.8 is the first release where `via_device_id`
exists in *both* `DeviceInfo` and `device_registry.async_get_or_create`; on 2026.7 and older
`async_get_or_create` has no `**kwargs` and passing it is a `TypeError`. `hacs.json` is raised
from the stale `2022.8` to `2026.8` — that file is the only place a minimum core version can be
declared for a custom integration, since HA's custom-integration manifest schema has no
`min_ha_version` key.

I deliberately did not add a runtime version branch. The two-key compatibility shim is more code
than the fix, and CI cannot exercise the old path anyway (see below), so it would ship untested.

## CI

Moves to Python 3.14. `pytest-homeassistant-custom-component` resolves by Python version, and
3.12 pins it to HA 2025.1.4 — a core with no `via_device_id`, where the new tests cannot run.
3.14 is the only version that resolves to a core new enough. `PyTurboJPEG==1.8.3` is added to
`requirements.test.txt` because `homeassistant.components.camera` imports `turbojpeg` at module
level since 2026.9, and without it the suite does not even collect. The workflow now also runs on
`push` and nightly, so core changes that break the integration surface without waiting for a PR.

## Verification

88 tests pass (73 existing + 15 new). The new regression tests were each confirmed to fail
against the unpatched source.

Beyond the test suite, both revisions were run against a real Home Assistant 2026.9.0 with a
mock ISAPI device replaying `tests/fixtures/devices/DS-7608NXI-I2.json`, plus a stub WebRTC
provider to reproduce the suspension point that go2rtc introduces in
`Camera.async_internal_added_to_hass`:

| | v1.1.1 | this PR |
|---|---|---|
| `RuntimeError: Detected code ...` | 8 | 0 |
| `Error adding entity camera....` | 8 | 0 |
| Deprecation warnings | 11 | 0 |
| **Camera entities registered** | **1 of 9** | **9 of 9** |
| Cameras nested under the NVR | yes | yes |

## Relation to the open PRs

#367 diagnosed the `via_device` bug correctly, including the point that `else None` does not
help. This takes the same direction but drops the pre-2026.8 branch and resolves the parent once
in `async_setup_entry` instead of per entity. #349 fixes the same two entity-id warnings, with
the same "slugify the entity id, leave `unique_id` alone" approach. #357 removes the explicit
entity ids entirely, which is the cleaner end state but is blocked today by `EventSwitch` and
`EventBinarySensor` setting `_attr_unique_id = self.entity_id`, which `coordinator.py` and
`notifications.py` then rebuild by hand. I have commented on all three.

## Note for the test suite

`device_registry.async_get_device()` is itself reported with `core_behavior=ERROR` in 2026.9, so
calling it from a test module raises `RuntimeError` — HA core hides this with an autouse fixture
that `pytest-homeassistant-custom-component` does not mirror. The new tests use
`async_get_device_by_identifier(identifier, config_entry_id)` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
