### PR TITLE
Fix via_device deprecation in Home Assistant 2026.9

### DIFF
--- a/custom_components/hikvision_next/__init__.py
+++ b/custom_components/hikvision_next/__init__.py
@@ -80,7 +80,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HikvisionConfigEntry) ->
 
 async def async_remove_config_entry_device(hass: HomeAssistant, config_entry, device_entry) -> bool:
     """Delete device if not entities."""
-    if not device_entry.via_device_id:
+    if not getattr(device_entry, "via_device_id", None) and not getattr(device_entry, "via_device", None):
         _LOGGER.error(
             "You cannot delete the NVR device via the device delete method.  Please remove the integration instead"
         )

--- a/custom_components/hikvision_next/hikvision_device.py
+++ b/custom_components/hikvision_next/hikvision_device.py
@@ -105,14 +105,40 @@ class HikvisionDevice(ISAPIClient):
             camera_info = self.get_camera_by_id(camera_id)
             is_ip_camera = isinstance(camera_info, IPCamera)
 
-            return DeviceInfo(
+            device_info = DeviceInfo(
                 manufacturer=self.device_info.manufacturer,
                 identifiers={(DOMAIN, camera_info.serial_no)},
                 model=camera_info.model,
                 name=camera_info.name,
                 sw_version=camera_info.firmware if is_ip_camera else "Unknown",
-                via_device=(DOMAIN, self.device_info.serial_no) if self.device_info.is_nvr else None,
             )
+
+            if self.device_info.is_nvr:
+                self._link_to_nvr(device_info)
+
+            return device_info
+
+    def _link_to_nvr(self, device_info: DeviceInfo) -> None:
+        """Link a camera device to the NVR it belongs to.
+
+        Home Assistant 2026.9 removed `via_device` from DeviceInfo and made the device registry
+        raise on it, so on those cores the key must be absent rather than None: the registry
+        reports it as soon as it is passed, whatever its value. Its replacement `via_device_id`,
+        and the lookup needed to fill it, only arrived in 2026.8, so both spellings are kept
+        while older cores are supported.
+        """
+        registry = dr.async_get(self.hass)
+        identifier = (DOMAIN, self.device_info.serial_no)
+
+        if hasattr(registry, "async_get_device_by_identifier"):
+            # async_setup_entry registers the NVR before it forwards the platforms, so the
+            # lookup finds it. Without a match the camera is still created, only unlinked.
+            if self.entry:
+                nvr_device = registry.async_get_device_by_identifier(identifier, self.entry.entry_id)
+                if nvr_device:
+                    device_info["via_device_id"] = nvr_device.id
+        else:
+            device_info["via_device"] = identifier
 
     def get_device_event_capabilities(
         self,


### PR DESCRIPTION
Fixes #371

This PR replaces the deprecated `via_device` with `via_device_id` in `DeviceInfo` to fix the issue where camera streams stop working after updating to Home Assistant 2026.9.0/2026.9.1. It also updates `async_remove_config_entry_device` to check for both `via_device_id` and `via_device`.